### PR TITLE
fix: Suppress stale read warnings in simulation mode

### DIFF
--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -457,6 +457,7 @@ class Microcontroller:
             raise ValueError("You must pass in an AbstractCephlaSerial device for the microcontroller instance to use.")
 
         self._serial = serial_device
+        self._is_simulated = isinstance(serial_device, SimSerial)
 
         self.tx_buffer_length = MicrocontrollerDef.CMD_LENGTH
         self.rx_buffer_length = MicrocontrollerDef.MSG_LENGTH
@@ -515,6 +516,8 @@ class Microcontroller:
             time.sleep(0.5)
 
     def _warn_if_reads_stale(self):
+        if self._is_simulated:
+            return
         now = time.time()
         last_read = float(
             self._last_successful_read_time


### PR DESCRIPTION
## Summary
- Add `_is_simulated` flag to `Microcontroller` class, set at initialization based on whether `SimSerial` is used
- Skip stale read warnings in `_warn_if_reads_stale()` when running in simulation mode
- Eliminates noisy warnings that are expected behavior when no real hardware is sending packets

## Test plan
- [x] Run `python3 main_hcs.py --simulation` and verify no "Read thread is stale" warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)