### PR TITLE
feat: Add Slack notifications for acquisition events

### DIFF
--- a/software/configurations/configuration_HCS_v2.ini
+++ b/software/configurations/configuration_HCS_v2.ini
@@ -242,3 +242,18 @@ channel6_gain = False
 _channel6_gain_options = [True, False]
 channel7_gain = True
 _channel7_gain_options = [True, False]
+
+[SLACK]
+enabled = False
+_enabled_options = [True, False]
+webhook_url = None
+notify_on_error = True
+_notify_on_error_options = [True, False]
+notify_on_timepoint_complete = True
+_notify_on_timepoint_complete_options = [True, False]
+notify_on_acquisition_start = False
+_notify_on_acquisition_start_options = [True, False]
+notify_on_acquisition_finished = True
+_notify_on_acquisition_finished_options = [True, False]
+send_mosaic_snapshots = True
+_send_mosaic_snapshots_options = [True, False]

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1082,6 +1082,19 @@ ENABLE_MCP_SERVER_SUPPORT = True  # Set to False to hide all MCP-related menu it
 CONTROL_SERVER_HOST = "127.0.0.1"
 CONTROL_SERVER_PORT = 5050
 
+
+# Slack Notifications - send real-time notifications during acquisition
+class SlackNotifications:
+    ENABLED = False
+    BOT_TOKEN = None  # Slack Bot Token (xoxb-...) for API access
+    CHANNEL_ID = None  # Slack Channel ID (C...) to post to
+    NOTIFY_ON_ERROR = True
+    NOTIFY_ON_TIMEPOINT_COMPLETE = True
+    NOTIFY_ON_ACQUISITION_START = False
+    NOTIFY_ON_ACQUISITION_FINISHED = True
+    SEND_MOSAIC_SNAPSHOTS = True
+
+
 try:
     with open("cache/config_file_path.txt", "r") as file:
         for line in file:

--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -213,6 +213,7 @@ class MultiPointController:
         self.thread: Optional[Thread] = None
         self._per_acq_log_handler = None
         self._memory_monitor: Optional[MemoryMonitor] = None
+        self._slack_notifier = None  # Optional SlackNotifier for notifications
 
         self.NX = 1
         self.deltaX = control._def.Acquisition.DX
@@ -256,6 +257,10 @@ class MultiPointController:
     def set_alignment_widget(self, alignment_widget):
         """Set the alignment widget for coordinate offset during acquisitions."""
         self._alignment_widget = alignment_widget
+
+    def set_slack_notifier(self, slack_notifier):
+        """Set the Slack notifier for acquisition notifications."""
+        self._slack_notifier = slack_notifier
 
     def _start_per_acquisition_log(self) -> None:
         if not control._def.ENABLE_PER_ACQUISITION_LOG:
@@ -815,6 +820,7 @@ class MultiPointController:
                 request_abort_fn=self.request_abort_aquisition,
                 extra_job_classes=[],
                 alignment_widget=self._alignment_widget,
+                slack_notifier=self._slack_notifier,
             )
 
             # Signal after worker creation so backpressure_controller is available

--- a/software/control/core/multi_point_utils.py
+++ b/software/control/core/multi_point_utils.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, Optional, Callable, Union
+from typing import List, Tuple, Dict, Optional, Callable, Union, TYPE_CHECKING
 
 from control._def import ZProjectionMode, DownsamplingMethod
 from control.core.job_processing import CaptureInfo
 from control.core.scan_coordinates import ScanCoordinates
 from control.models import AcquisitionChannel
 from squid.abc import CameraFrame
+
+if TYPE_CHECKING:
+    from control.slack_notifier import TimepointStats, AcquisitionStats
 
 
 @dataclass
@@ -116,3 +119,6 @@ class MultiPointControllerFunctions:
     # Unlike mutable defaults (lists/dicts), lambdas are safe as defaults since they're not modified.
     signal_plate_view_init: Callable[[PlateViewInit], None] = lambda *a, **kw: None
     signal_plate_view_update: Callable[[PlateViewUpdate], None] = lambda *a, **kw: None
+    # Optional Slack notification callbacks (allows main thread to capture screenshot and maintain ordering)
+    signal_slack_timepoint_notification: Callable[["TimepointStats"], None] = lambda *a, **kw: None
+    signal_slack_acquisition_finished: Callable[["AcquisitionStats"], None] = lambda *a, **kw: None

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -13,6 +13,7 @@ from control._def import *
 from control._def import DOWNSAMPLED_VIEW_JOB_TIMEOUT_S, DOWNSAMPLED_VIEW_IDLE_TIMEOUT_S
 import control._def
 from control import utils
+from control.slack_notifier import TimepointStats, AcquisitionStats
 from control.core.auto_focus_controller import AutoFocusController
 from control.core.laser_auto_focus_controller import LaserAutofocusController
 from control.core.live_controller import LiveController
@@ -76,10 +77,20 @@ class MultiPointWorker:
         extra_job_classes: list[type[Job]] | None = None,
         abort_on_failed_jobs: bool = True,
         alignment_widget=None,
+        slack_notifier=None,
     ):
         self._log = squid.logging.get_logger(__class__.__name__)
         self._timing = utils.TimingManager("MultiPointWorker Timer Manager")
         self._alignment_widget = alignment_widget  # Optional AlignmentWidget for coordinate offset
+        self._slack_notifier = slack_notifier  # Optional SlackNotifier for notifications
+
+        # Slack notification tracking counters
+        self._timepoint_image_count = 0
+        self._timepoint_fov_count = 0
+        self._timepoint_start_time = 0.0
+        self._acquisition_error_count = 0
+        self._laser_af_successes = 0
+        self._laser_af_failures = 0
         self.microscope: Microscope = scope
         self.camera: AbstractCamera = scope.camera
         self.microcontroller: Microcontroller = scope.low_level_drivers.microcontroller
@@ -342,6 +353,19 @@ class MultiPointWorker:
             this_image_callback_id = self.camera.add_frame_callback(self._image_callback)
             sleep_time = min(self.dt / 20.0, 0.5)
 
+            # Send Slack acquisition start notification
+            if self._slack_notifier is not None:
+                try:
+                    self._slack_notifier.notify_acquisition_start(
+                        experiment_id=self.experiment_ID or "unknown",
+                        num_regions=len(self.scan_region_names) if self.scan_region_names else 0,
+                        num_timepoints=self.Nt,
+                        num_channels=len(self.selected_configurations) if self.selected_configurations else 0,
+                        num_z_levels=self.NZ,
+                    )
+                except Exception as e:
+                    self._log.warning(f"Failed to send Slack acquisition start notification: {e}")
+
             while self.time_point < self.Nt:
                 # check if abort acquisition has been requested
                 if self.abort_requested_fn():
@@ -405,6 +429,22 @@ class MultiPointWorker:
                 self.camera.remove_frame_callback(this_image_callback_id)
 
             self._finish_jobs()
+
+            # Send Slack acquisition finished notification via callback (ensures ordering with timepoint notifications)
+            if self._slack_notifier is not None:
+                try:
+                    total_duration = time.time() - self.timestamp_acquisition_started
+                    stats = AcquisitionStats(
+                        total_images=self.image_count,
+                        total_timepoints=self.time_point,
+                        total_duration_seconds=total_duration,
+                        errors_encountered=self._acquisition_error_count,
+                        experiment_id=self.experiment_ID or "unknown",
+                    )
+                    self.callbacks.signal_slack_acquisition_finished(stats)
+                except Exception as e:
+                    self._log.warning(f"Failed to send Slack acquisition finished notification: {e}")
+
             self.callbacks.signal_acquisition_finished()
 
     def _wait_for_outstanding_callback_images(self):
@@ -469,6 +509,11 @@ class MultiPointWorker:
     def run_single_time_point(self):
         try:
             start = time.time()
+            self._timepoint_start_time = start
+            self._timepoint_image_count = 0
+            self._timepoint_fov_count = 0
+            self._laser_af_successes = 0
+            self._laser_af_failures = 0
             self.microcontroller.enable_joystick(False)
 
             self._log.debug("multipoint acquisition - time point " + str(self.time_point + 1))
@@ -502,6 +547,29 @@ class MultiPointWorker:
 
             # finished region scan
             self.coordinates_pd.to_csv(os.path.join(current_path, "coordinates.csv"), index=False, header=True)
+
+            # Send Slack timepoint notification via callback (allows main thread to capture screenshot)
+            if self._slack_notifier is not None:
+                try:
+                    elapsed = time.time() - self.timestamp_acquisition_started
+                    timepoint_duration = time.time() - self._timepoint_start_time
+                    self._slack_notifier.record_timepoint_duration(timepoint_duration)
+                    estimated_remaining = self._slack_notifier.estimate_remaining_time(self.time_point + 1, self.Nt)
+                    stats = TimepointStats(
+                        timepoint=self.time_point + 1,
+                        total_timepoints=self.Nt,
+                        elapsed_seconds=elapsed,
+                        estimated_remaining_seconds=estimated_remaining,
+                        images_captured=self._timepoint_image_count,
+                        fovs_captured=self._timepoint_fov_count,
+                        laser_af_successes=self._laser_af_successes,
+                        laser_af_failures=self._laser_af_failures,
+                        laser_af_failure_reasons=[],
+                    )
+                    # Use callback to allow main thread to capture screenshot before sending
+                    self.callbacks.signal_slack_timepoint_notification(stats)
+                except Exception as e:
+                    self._log.warning(f"Failed to send Slack timepoint notification: {e}")
 
             utils.create_done_file(current_path)
             self._log.debug(f"Single time point took: {time.time() - start} [s]")
@@ -613,6 +681,18 @@ class MultiPointWorker:
         """
         if job_result.exception is not None:
             self._log.error(f"Error while running job {job_result.job_id}: {job_result.exception}")
+            self._acquisition_error_count += 1
+
+            # Send Slack error notification
+            if self._slack_notifier is not None:
+                try:
+                    context = {"job_id": job_result.job_id}
+                    self._slack_notifier.notify_error(
+                        str(job_result.exception),
+                        context,
+                    )
+                except Exception as e:
+                    self._log.warning(f"Failed to send Slack error notification: {e}")
             return False
         else:
             self._log.info(f"Got result for job {job_result.job_id}, it completed!")
@@ -1095,6 +1175,9 @@ class MultiPointWorker:
         if self.NZ > 1:
             self.move_z_back_after_stack()
 
+        # Increment FOV counter for Slack notification stats
+        self._timepoint_fov_count += 1
+
     def _select_config(self, config: AcquisitionChannel):
         self.callbacks.signal_current_configuration(config)
         self.liveController.set_microscope_mode(config)
@@ -1122,6 +1205,7 @@ class MultiPointWorker:
             self._log.info("laser reflection af")
             try:
                 self.laser_auto_focus_controller.move_to_target(0)
+                self._laser_af_successes += 1
             except Exception as e:
                 file_ID = f"{region_id}_focus_camera.bmp"
                 saving_path = os.path.join(self.base_path, self.experiment_ID, str(self.time_point), file_ID)
@@ -1130,6 +1214,7 @@ class MultiPointWorker:
                     "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! laser AF failed !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
                     exc_info=e,
                 )
+                self._laser_af_failures += 1
                 return False
         return True
 
@@ -1174,6 +1259,10 @@ class MultiPointWorker:
                     self._log.warning("image in frame callback is None. Something is really wrong, aborting!")
                     self.request_abort_fn()
                     return
+
+                # Increment image counter for Slack notification stats
+                self._timepoint_image_count += 1
+                self.image_count += 1
 
                 with self._timing.get_timer("job creation and dispatch"):
                     for job_class, job_runner in self._job_runners:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -90,6 +90,10 @@ if RUN_FLUIDICS:
 # Import the custom widget
 from control.custom_multipoint_widget import TemplateMultiPointWidget
 
+# Slack notifications
+from control.slack_notifier import SlackNotifier, TimepointStats, AcquisitionStats
+from control.widgets_slack import SlackSettingsDialog, load_slack_settings_from_cache
+
 
 class MovementUpdater(QObject):
     position_after_move = Signal(squid.abc.Pos)
@@ -186,6 +190,9 @@ class QtMultiPointController(MultiPointController, QObject):
     # Plate view signals
     plate_view_init = Signal(int, int, tuple, tuple, list)  # rows, cols, well_slot_shape, fov_grid_shape, channel_names
     plate_view_update = Signal(int, str, np.ndarray)  # channel_idx, channel_name, plate_image
+    # Slack notification signals (allows main thread to capture screenshot and maintain ordering)
+    signal_slack_timepoint = Signal(object)  # TimepointStats
+    signal_slack_acq_finished = Signal(object)  # AcquisitionStats
 
     def __init__(
         self,
@@ -214,6 +221,8 @@ class QtMultiPointController(MultiPointController, QObject):
                 signal_region_progress=self._signal_region_progress_fn,
                 signal_plate_view_init=self._signal_plate_view_init_fn,
                 signal_plate_view_update=self._signal_plate_view_update_fn,
+                signal_slack_timepoint_notification=self._signal_slack_timepoint_notification_fn,
+                signal_slack_acquisition_finished=self._signal_slack_acquisition_finished_fn,
             ),
             scan_coordinates=scan_coordinates,
             laser_autofocus_controller=laser_autofocus_controller,
@@ -293,6 +302,12 @@ class QtMultiPointController(MultiPointController, QObject):
             plate_view_update.plate_image,
         )
 
+    def _signal_slack_timepoint_notification_fn(self, stats: TimepointStats):
+        self.signal_slack_timepoint.emit(stats)
+
+    def _signal_slack_acquisition_finished_fn(self, stats: AcquisitionStats):
+        self.signal_slack_acq_finished.emit(stats)
+
 
 class HighContentScreeningGui(QMainWindow):
     fps_software_trigger = 100
@@ -366,6 +381,12 @@ class HighContentScreeningGui(QMainWindow):
         self.trackingController: core.TrackingController = None
         self.navigationViewer: core.NavigationViewer = None
         self.scanCoordinates: Optional[ScanCoordinates] = None
+        self.slackNotifier: Optional[SlackNotifier] = None
+        self.slackSettingsDialog: Optional[SlackSettingsDialog] = None
+
+        # Load Slack settings from cache
+        load_slack_settings_from_cache()
+
         self.load_objects(is_simulation=is_simulation)
         self.setup_hardware()
 
@@ -424,6 +445,9 @@ class HighContentScreeningGui(QMainWindow):
         # Initialize live scan grid state
         self.wellplateMultiPointWidget.initialize_live_scan_grid_state()
 
+        # Initialize Slack notifier
+        self._setup_slack_notifier()
+
         # TODO(imo): Why is moving to the cached position after boot hidden behind homing?
         if HOMING_ENABLED_X and HOMING_ENABLED_Y and HOMING_ENABLED_Z:
             if cached_pos := squid.stage.utils.get_cached_position():
@@ -460,6 +484,12 @@ class HighContentScreeningGui(QMainWindow):
             led_matrix_action = QAction("LED Matrix", self)
             led_matrix_action.triggered.connect(self.openLedMatrixSettings)
             settings_menu.addAction(led_matrix_action)
+
+        # Slack notifications
+        slack_action = QAction("Slack Notifications...", self)
+        slack_action.setMenuRole(QAction.NoRole)
+        slack_action.triggered.connect(self.openSlackSettings)
+        settings_menu.addAction(slack_action)
 
         # Advanced submenu
         advanced_menu = settings_menu.addMenu("Advanced")
@@ -1604,6 +1634,56 @@ class HighContentScreeningGui(QMainWindow):
             dialog.exec_()
         else:
             self.log.warning("No configuration file found")
+
+    def _setup_slack_notifier(self):
+        """Initialize the Slack notifier and wire up connections."""
+        # Create the slack notifier
+        self.slackNotifier = SlackNotifier()
+
+        # Set slack notifier on multipoint controller
+        if self.multipointController is not None:
+            self.multipointController.set_slack_notifier(self.slackNotifier)
+            # Connect Slack notification signals to handlers (runs on main thread for proper ordering)
+            self.multipointController.signal_slack_timepoint.connect(self._handle_slack_timepoint_notification)
+            self.multipointController.signal_slack_acq_finished.connect(self._handle_slack_acquisition_finished)
+
+        self.log.info("Slack notifier initialized")
+
+    def _handle_slack_timepoint_notification(self, stats: TimepointStats):
+        """Handle Slack timepoint notification on the main Qt thread.
+
+        Captures screenshot from mosaic widget (if available) and sends notification.
+        """
+        try:
+            # Capture screenshot from mosaic widget (must be done on main Qt thread)
+            mosaic_image = None
+            if self.napariMosaicDisplayWidget is not None:
+                mosaic_image = self.napariMosaicDisplayWidget.get_screenshot()
+
+            # Send notification with screenshot
+            if self.slackNotifier is not None:
+                self.slackNotifier.notify_timepoint_complete(stats, mosaic_image)
+        except Exception as e:
+            self.log.warning(f"Failed to send Slack timepoint notification: {e}")
+
+    def _handle_slack_acquisition_finished(self, stats: AcquisitionStats):
+        """Handle Slack acquisition finished notification on the main Qt thread."""
+        try:
+            if self.slackNotifier is not None:
+                self.slackNotifier.notify_acquisition_finished(stats)
+        except Exception as e:
+            self.log.warning(f"Failed to send Slack acquisition finished notification: {e}")
+
+    def openSlackSettings(self):
+        """Open the Slack notifications settings dialog."""
+        if self.slackSettingsDialog is None:
+            self.slackSettingsDialog = SlackSettingsDialog(
+                slack_notifier=self.slackNotifier,
+                parent=self,
+            )
+        self.slackSettingsDialog.show()
+        self.slackSettingsDialog.raise_()
+        self.slackSettingsDialog.activateWindow()
 
     def openChannelConfigurationEditor(self):
         """Open the illumination channel configurator dialog"""

--- a/software/control/slack_notifier.py
+++ b/software/control/slack_notifier.py
@@ -1,0 +1,704 @@
+"""Slack notification system for Squid microscope acquisitions.
+
+Provides real-time Slack notifications for acquisition events including errors,
+timepoint completions, and acquisition start/end. Uses a background thread
+queue to avoid blocking acquisition operations.
+
+Uses Slack Bot API for message posting and image uploads.
+"""
+
+import io
+import json
+import queue
+import threading
+import time
+import urllib.request
+import urllib.error
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Dict, Any, Callable, Tuple
+
+import numpy as np
+
+import control._def
+import squid.logging
+
+log = squid.logging.get_logger(__name__)
+
+
+@dataclass
+class TimepointStats:
+    """Statistics for a completed timepoint."""
+
+    timepoint: int
+    total_timepoints: int
+    elapsed_seconds: float
+    estimated_remaining_seconds: float
+    images_captured: int
+    fovs_captured: int
+    laser_af_successes: int
+    laser_af_failures: int
+    laser_af_failure_reasons: list
+
+
+@dataclass
+class AcquisitionStats:
+    """Statistics for a completed acquisition."""
+
+    total_images: int
+    total_timepoints: int
+    total_duration_seconds: float
+    errors_encountered: int
+    experiment_id: str
+
+
+@dataclass
+class SlackMessage:
+    """A message to be sent to Slack, optionally with an image."""
+
+    text: str
+    blocks: Optional[list] = None
+    image_data: Optional[bytes] = None
+    image_title: Optional[str] = None
+
+
+class SlackNotifier:
+    """Sends notifications to Slack via Bot API.
+
+    Uses a background thread with a queue to dispatch messages without
+    blocking the acquisition thread. Supports rate limiting for error
+    messages to prevent spam. Supports image uploads via the Slack API.
+    """
+
+    ERROR_THROTTLE_SECONDS = 5.0  # Minimum time between error notifications
+    MAX_IMAGE_SIZE = 1024  # Maximum dimension for image attachments
+    QUEUE_TIMEOUT = 1.0  # Timeout for queue operations
+    SLACK_API_BASE = "https://slack.com/api"
+
+    def __init__(
+        self,
+        bot_token: Optional[str] = None,
+        channel_id: Optional[str] = None,
+    ):
+        """Initialize the Slack notifier.
+
+        Args:
+            bot_token: Slack Bot Token (xoxb-...) for API access.
+            channel_id: Slack Channel ID (C...) to post to.
+        """
+        self._bot_token = bot_token
+        self._channel_id = channel_id
+        self._message_queue: queue.Queue = queue.Queue()
+        self._worker_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._last_error_time: Dict[str, float] = {}
+        self._lock = threading.Lock()
+
+        # Track acquisition state
+        self._acquisition_start_time: Optional[float] = None
+        self._current_experiment_id: Optional[str] = None
+        self._timepoint_durations: list = []
+
+        # Pending image for next message (set from main thread via signal)
+        self._pending_image: Optional[bytes] = None
+        self._pending_image_lock = threading.Lock()
+
+        # Start the background worker thread
+        self._start_worker()
+
+    @property
+    def bot_token(self) -> Optional[str]:
+        """Get the current bot token, preferring instance value over config."""
+        if self._bot_token:
+            return self._bot_token
+        return control._def.SlackNotifications.BOT_TOKEN
+
+    @bot_token.setter
+    def bot_token(self, value: Optional[str]):
+        """Set the bot token."""
+        self._bot_token = value
+
+    @property
+    def channel_id(self) -> Optional[str]:
+        """Get the current channel ID, preferring instance value over config."""
+        if self._channel_id:
+            return self._channel_id
+        return control._def.SlackNotifications.CHANNEL_ID
+
+    @channel_id.setter
+    def channel_id(self, value: Optional[str]):
+        """Set the channel ID."""
+        self._channel_id = value
+
+    @property
+    def enabled(self) -> bool:
+        """Check if Slack notifications are enabled."""
+        return control._def.SlackNotifications.ENABLED and self.bot_token is not None and self.channel_id is not None
+
+    def _start_worker(self):
+        """Start the background worker thread."""
+        if self._worker_thread is not None and self._worker_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._worker_thread = threading.Thread(target=self._worker_loop, daemon=True, name="SlackNotifierWorker")
+        self._worker_thread.start()
+
+    def _worker_loop(self):
+        """Background worker loop that processes the message queue."""
+        while not self._stop_event.is_set():
+            try:
+                message = self._message_queue.get(timeout=self.QUEUE_TIMEOUT)
+                if message is None:  # Shutdown signal
+                    break
+                if isinstance(message, SlackMessage):
+                    self._send_message(message)
+                else:
+                    # Legacy dict format
+                    self._post_message(message.get("text", ""), message.get("blocks"))
+            except queue.Empty:
+                continue
+            except Exception as e:
+                log.warning(f"Error in Slack worker loop: {e}")
+
+    def _post_message(self, text: str, blocks: Optional[list] = None) -> Tuple[bool, Optional[str]]:
+        """Post a message to Slack using chat.postMessage API.
+
+        Args:
+            text: Fallback text for the message.
+            blocks: Optional Block Kit blocks for rich formatting.
+
+        Returns:
+            Tuple of (success, message_ts) where message_ts is the timestamp
+            of the posted message (used for threading).
+        """
+        token = self.bot_token
+        channel = self.channel_id
+
+        if not token or not channel:
+            log.debug("No Slack bot token or channel configured")
+            return False, None
+
+        try:
+            log.info(f"Sending Slack message: {text[:50]}")
+            payload = {
+                "channel": channel,
+                "text": text,
+            }
+            if blocks:
+                payload["blocks"] = blocks
+
+            data = json.dumps(payload).encode("utf-8")
+            request = urllib.request.Request(
+                f"{self.SLACK_API_BASE}/chat.postMessage",
+                data=data,
+                headers={
+                    "Content-Type": "application/json; charset=utf-8",
+                    "Authorization": f"Bearer {token}",
+                },
+                method="POST",
+            )
+
+            with urllib.request.urlopen(request, timeout=15) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                if result.get("ok"):
+                    log.info("Slack message sent successfully")
+                    return True, result.get("ts")
+                else:
+                    log.warning(f"Slack API error: {result.get('error')}")
+                    return False, None
+
+        except urllib.error.URLError as e:
+            log.warning(f"Failed to send Slack message: {e}")
+            return False, None
+        except Exception as e:
+            log.warning(f"Unexpected error sending Slack message: {e}")
+            return False, None
+
+    def _upload_image(
+        self,
+        image_data: bytes,
+        title: str,
+        initial_comment: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+    ) -> bool:
+        """Upload an image to Slack using the new files.getUploadURLExternal API.
+
+        The new Slack file upload flow:
+        1. Call files.getUploadURLExternal to get an upload URL and file_id
+        2. Upload the file content to that URL
+        3. Call files.completeUploadExternal to complete and share to channel
+
+        Args:
+            image_data: PNG image data as bytes.
+            title: Title for the image.
+            initial_comment: Optional comment to post with the image.
+            thread_ts: Optional thread timestamp to post as reply.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        token = self.bot_token
+        channel = self.channel_id
+
+        if not token or not channel:
+            log.debug("No Slack bot token or channel configured")
+            return False
+
+        if not image_data:
+            log.debug("No image data to upload")
+            return False
+
+        try:
+            log.info(f"Uploading image to Slack: {title}")
+            filename = "mosaic.png"
+
+            # Step 1: Get upload URL (uses form-urlencoded params)
+            get_url_params = urllib.parse.urlencode(
+                {
+                    "filename": filename,
+                    "length": len(image_data),
+                }
+            ).encode("utf-8")
+            get_url_request = urllib.request.Request(
+                f"{self.SLACK_API_BASE}/files.getUploadURLExternal",
+                data=get_url_params,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": f"Bearer {token}",
+                },
+                method="POST",
+            )
+
+            with urllib.request.urlopen(get_url_request, timeout=15) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                if not result.get("ok"):
+                    log.warning(f"Slack API error getting upload URL: {result.get('error')}")
+                    return False
+                upload_url = result.get("upload_url")
+                file_id = result.get("file_id")
+                log.debug(f"Got upload URL, file_id={file_id}")
+
+            # Step 2: Upload file content to the URL
+            upload_request = urllib.request.Request(
+                upload_url,
+                data=image_data,
+                headers={
+                    "Content-Type": "application/octet-stream",
+                },
+                method="POST",
+            )
+
+            with urllib.request.urlopen(upload_request, timeout=30) as response:
+                # Upload endpoint returns 200 on success
+                if response.status != 200:
+                    log.warning(f"Failed to upload file content: HTTP {response.status}")
+                    return False
+
+            # Step 3: Complete upload and share to channel
+            # The files parameter must be a JSON-encoded string
+            files_json = json.dumps([{"id": file_id, "title": title}])
+            complete_params = {
+                "files": files_json,
+                "channel_id": channel,
+            }
+            log.debug(f"Completing upload with params: {complete_params}")
+            if thread_ts:
+                complete_params["thread_ts"] = thread_ts
+            if initial_comment:
+                complete_params["initial_comment"] = initial_comment
+
+            complete_request = urllib.request.Request(
+                f"{self.SLACK_API_BASE}/files.completeUploadExternal",
+                data=urllib.parse.urlencode(complete_params).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": f"Bearer {token}",
+                },
+                method="POST",
+            )
+
+            with urllib.request.urlopen(complete_request, timeout=15) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                if result.get("ok"):
+                    log.info("Slack image uploaded successfully")
+                    return True
+                else:
+                    log.warning(f"Slack API error completing upload: {result}")
+                    return False
+
+        except urllib.error.URLError as e:
+            log.warning(f"Failed to upload image to Slack: {e}")
+            return False
+        except Exception as e:
+            log.warning(f"Unexpected error uploading image to Slack: {e}")
+            return False
+
+    def _send_message(self, message: SlackMessage):
+        """Send a SlackMessage, including image upload if present."""
+        # First post the text message
+        success, ts = self._post_message(message.text, message.blocks)
+
+        # If there's an image and message was successful, upload it as a reply
+        if success and message.image_data and control._def.SlackNotifications.SEND_MOSAIC_SNAPSHOTS:
+            self._upload_image(
+                message.image_data,
+                message.image_title or "Mosaic",
+                thread_ts=ts,
+            )
+
+    def _queue_message(self, message: SlackMessage):
+        """Add a message to the dispatch queue."""
+        if not self.enabled:
+            log.debug(f"Slack notifications disabled, skipping message: {message.text[:50]}")
+            return
+        try:
+            log.info(f"Queuing Slack message: {message.text[:50]}")
+            self._message_queue.put_nowait(message)
+        except queue.Full:
+            log.warning("Slack message queue full, dropping notification")
+
+    def _should_throttle_error(self, error_key: str) -> bool:
+        """Check if an error notification should be throttled."""
+        with self._lock:
+            now = time.time()
+            last_time = self._last_error_time.get(error_key, 0)
+            if now - last_time < self.ERROR_THROTTLE_SECONDS:
+                return True
+            self._last_error_time[error_key] = now
+            return False
+
+    def _image_to_png_bytes(self, image: np.ndarray) -> bytes:
+        """Convert a numpy array to PNG bytes."""
+        try:
+            from PIL import Image
+
+            # Ensure image is in correct format
+            if image.dtype == np.uint16:
+                # Scale to 8-bit
+                image = (image / 256).astype(np.uint8)
+            elif image.dtype != np.uint8:
+                image = image.astype(np.uint8)
+
+            # Resize if too large
+            h, w = image.shape[:2]
+            if max(h, w) > self.MAX_IMAGE_SIZE:
+                scale = self.MAX_IMAGE_SIZE / max(h, w)
+                new_w = int(w * scale)
+                new_h = int(h * scale)
+                pil_image = Image.fromarray(image)
+                pil_image = pil_image.resize((new_w, new_h), Image.LANCZOS)
+            else:
+                pil_image = Image.fromarray(image)
+
+            # Convert to PNG bytes
+            buffer = io.BytesIO()
+            pil_image.save(buffer, format="PNG")
+            return buffer.getvalue()
+        except ImportError:
+            log.warning("PIL not available, cannot convert image to PNG")
+            return b""
+        except Exception as e:
+            log.warning(f"Failed to convert image to PNG: {e}")
+            return b""
+
+    def _format_duration(self, seconds: float) -> str:
+        """Format a duration in seconds to a human-readable string."""
+        if seconds < 60:
+            return f"{seconds:.0f}s"
+        elif seconds < 3600:
+            minutes = seconds / 60
+            return f"{minutes:.0f}m"
+        else:
+            hours = int(seconds // 3600)
+            minutes = int((seconds % 3600) // 60)
+            return f"{hours}h {minutes}m"
+
+    def set_pending_image(self, image: Optional[np.ndarray]):
+        """Set a pending image to be sent with the next timepoint notification.
+
+        This should be called from the main Qt thread after capturing a screenshot.
+
+        Args:
+            image: Screenshot as numpy array, or None to clear.
+        """
+        with self._pending_image_lock:
+            if image is not None:
+                self._pending_image = self._image_to_png_bytes(image)
+            else:
+                self._pending_image = None
+
+    def get_and_clear_pending_image(self) -> Optional[bytes]:
+        """Get and clear the pending image data."""
+        with self._pending_image_lock:
+            image = self._pending_image
+            self._pending_image = None
+            return image
+
+    def send_message(self, text: str, blocks: Optional[list] = None):
+        """Send a text message to Slack.
+
+        Args:
+            text: Fallback text for notifications.
+            blocks: Optional Slack Block Kit blocks for rich formatting.
+        """
+        message = SlackMessage(text=text, blocks=blocks)
+        self._queue_message(message)
+
+    def notify_error(self, error_msg: str, context: Optional[Dict[str, Any]] = None):
+        """Send an error notification to Slack."""
+        if not control._def.SlackNotifications.NOTIFY_ON_ERROR:
+            return
+
+        # Throttle repeated errors of the same type
+        error_key = error_msg[:50]
+        if self._should_throttle_error(error_key):
+            log.debug(f"Throttling Slack error notification: {error_key}")
+            return
+
+        # Build context string
+        context_str = ""
+        if context:
+            parts = []
+            if "region" in context:
+                parts.append(f"Region {context['region']}")
+            if "fov" in context:
+                parts.append(f"FOV {context['fov']}")
+            if "z_level" in context:
+                parts.append(f"Z-level {context['z_level']}")
+            if "channel" in context:
+                parts.append(f"Channel: {context['channel']}")
+            if "job_id" in context:
+                parts.append(f"Job: {context['job_id'][:8]}")
+            context_str = ", ".join(parts)
+
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Acquisition Error", "emoji": True},
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Error:* {error_msg}\n*Location:* {context_str or 'N/A'}\n*Time:* {timestamp}",
+                },
+            },
+        ]
+
+        if self._current_experiment_id:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": f"Experiment: {self._current_experiment_id}"}],
+                }
+            )
+
+        message = SlackMessage(text=f"Acquisition Error: {error_msg}", blocks=blocks)
+        self._queue_message(message)
+
+    def notify_timepoint_complete(
+        self,
+        stats: TimepointStats,
+        mosaic_image: Optional[np.ndarray] = None,
+    ):
+        """Send a timepoint completion notification to Slack."""
+        if not control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE:
+            return
+
+        # Convert image to PNG if provided
+        image_data = None
+        if mosaic_image is not None:
+            image_data = self._image_to_png_bytes(mosaic_image)
+        else:
+            # Check for pending image (set from main thread)
+            image_data = self.get_and_clear_pending_image()
+
+        # Format times
+        elapsed_str = self._format_duration(stats.elapsed_seconds)
+        remaining_str = self._format_duration(stats.estimated_remaining_seconds)
+
+        # Build stats text
+        stats_text = (
+            f"*Elapsed:* {elapsed_str}\n"
+            f"*Remaining:* ~{remaining_str}\n"
+            f"*Images:* {stats.images_captured:,}\n"
+            f"*FOVs:* {stats.fovs_captured:,}"
+        )
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"Timepoint {stats.timepoint}/{stats.total_timepoints} Complete",
+                    "emoji": True,
+                },
+            },
+            {"type": "section", "text": {"type": "mrkdwn", "text": stats_text}},
+        ]
+
+        # Add laser AF stats if applicable
+        total_af = stats.laser_af_successes + stats.laser_af_failures
+        if total_af > 0:
+            af_text = f"*Laser AF:* {stats.laser_af_successes}/{total_af} FOVs succeeded"
+            if stats.laser_af_failures > 0:
+                af_text += f" ({stats.laser_af_failures} failed)"
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": af_text}})
+
+        if self._current_experiment_id:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": f"Experiment: {self._current_experiment_id}"}],
+                }
+            )
+
+        message = SlackMessage(
+            text=f"Timepoint {stats.timepoint}/{stats.total_timepoints} complete",
+            blocks=blocks,
+            image_data=image_data,
+            image_title=f"Mosaic - Timepoint {stats.timepoint}",
+        )
+        self._queue_message(message)
+
+    def notify_acquisition_start(
+        self,
+        experiment_id: str,
+        num_regions: int,
+        num_timepoints: int,
+        num_channels: int,
+        num_z_levels: int,
+    ):
+        """Send an acquisition start notification to Slack."""
+        if not control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_START:
+            return
+
+        self._acquisition_start_time = time.time()
+        self._current_experiment_id = experiment_id
+        self._timepoint_durations = []
+
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Acquisition Started", "emoji": True},
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Experiment:* {experiment_id}\n"
+                        f"*Regions:* {num_regions}\n"
+                        f"*Timepoints:* {num_timepoints}\n"
+                        f"*Channels:* {num_channels}\n"
+                        f"*Z-levels:* {num_z_levels}\n"
+                        f"*Started:* {timestamp}"
+                    ),
+                },
+            },
+        ]
+
+        message = SlackMessage(text=f"Acquisition started: {experiment_id}", blocks=blocks)
+        self._queue_message(message)
+
+    def notify_acquisition_finished(self, stats: AcquisitionStats):
+        """Send an acquisition completion notification to Slack."""
+        if not control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_FINISHED:
+            return
+
+        duration_str = self._format_duration(stats.total_duration_seconds)
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        status_text = f"with {stats.errors_encountered} errors" if stats.errors_encountered > 0 else "successfully"
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Acquisition Complete", "emoji": True},
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Experiment:* {stats.experiment_id}\n"
+                        f"*Status:* Finished {status_text}\n"
+                        f"*Total Images:* {stats.total_images:,}\n"
+                        f"*Timepoints:* {stats.total_timepoints}\n"
+                        f"*Duration:* {duration_str}\n"
+                        f"*Completed:* {timestamp}"
+                    ),
+                },
+            },
+        ]
+
+        message = SlackMessage(
+            text=f"Acquisition complete: {stats.experiment_id} ({status_text})",
+            blocks=blocks,
+        )
+        self._queue_message(message)
+
+        # Reset state
+        self._acquisition_start_time = None
+        self._current_experiment_id = None
+        self._timepoint_durations = []
+
+    def record_timepoint_duration(self, duration_seconds: float):
+        """Record the duration of a completed timepoint for estimation."""
+        self._timepoint_durations.append(duration_seconds)
+
+    def estimate_remaining_time(self, current_timepoint: int, total_timepoints: int) -> float:
+        """Estimate remaining acquisition time based on past timepoint durations."""
+        if not self._timepoint_durations:
+            return 0.0
+        avg_duration = sum(self._timepoint_durations) / len(self._timepoint_durations)
+        remaining_timepoints = total_timepoints - current_timepoint
+        return avg_duration * remaining_timepoints
+
+    def test_connection(self) -> Tuple[bool, str]:
+        """Test the Slack API connection.
+
+        Returns:
+            Tuple of (success, message).
+        """
+        token = self.bot_token
+        channel = self.channel_id
+
+        if not token:
+            return False, "No bot token configured"
+        if not channel:
+            return False, "No channel ID configured"
+
+        # Test by posting a message
+        success, _ = self._post_message(
+            "Squid Microscope: Test connection successful!",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Squid Microscope Slack integration test successful!",
+                    },
+                }
+            ],
+        )
+
+        if success:
+            return True, "Connection successful"
+        return False, "Failed to send test message"
+
+    def close(self):
+        """Shutdown the notifier and worker thread."""
+        self._stop_event.set()
+        try:
+            self._message_queue.put_nowait(None)
+        except queue.Full:
+            pass
+
+        if self._worker_thread and self._worker_thread.is_alive():
+            self._worker_thread.join(timeout=2.0)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -11087,6 +11087,20 @@ class NapariMosaicDisplayWidget(QWidget):
     def activate(self):
         self.viewer.window.activate()
 
+    def get_screenshot(self) -> Optional[np.ndarray]:
+        """Capture the current mosaic view as a numpy array.
+
+        Returns:
+            RGB image array of the current view, or None if no layers exist.
+        """
+        if not self.layers_initialized:
+            return None
+        try:
+            # Use napari's screenshot functionality
+            return self.viewer.screenshot(canvas_only=True)
+        except Exception:
+            return None
+
 
 class NapariPlateViewWidget(QWidget):
     """Widget for displaying downsampled plate view with multi-channel support.

--- a/software/control/widgets_slack.py
+++ b/software/control/widgets_slack.py
@@ -1,0 +1,349 @@
+"""Slack notification settings dialog for Squid microscope GUI.
+
+Provides a non-modal dialog for configuring Slack Bot Token, Channel ID,
+and notification preferences. Changes apply immediately without restart.
+"""
+
+import os
+from typing import Optional
+
+import yaml
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QCheckBox,
+    QPushButton,
+    QGroupBox,
+    QMessageBox,
+    QFormLayout,
+)
+
+import control._def
+from control.slack_notifier import SlackNotifier
+import squid.logging
+
+log = squid.logging.get_logger(__name__)
+
+CACHE_FILE = "cache/slack_settings.yaml"
+
+
+class SlackSettingsDialog(QDialog):
+    """Non-modal dialog for configuring Slack notifications.
+
+    Settings are saved to a cache file and override INI config values
+    at runtime. Changes take effect immediately.
+    """
+
+    settings_changed = Signal()
+
+    def __init__(
+        self,
+        slack_notifier: Optional[SlackNotifier] = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._slack_notifier = slack_notifier
+        self.setWindowTitle("Slack Notifications")
+        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+        self.setModal(False)
+        self.setMinimumWidth(500)
+
+        self._setup_ui()
+        self._load_settings()
+        self._connect_signals()
+
+    def _setup_ui(self):
+        """Set up the dialog UI."""
+        layout = QVBoxLayout(self)
+
+        # API Configuration section
+        api_group = QGroupBox("Slack API Configuration")
+        api_layout = QFormLayout()
+
+        self.checkbox_enabled = QCheckBox("Enable Slack Notifications")
+        api_layout.addRow(self.checkbox_enabled)
+
+        # Bot Token
+        self.lineedit_bot_token = QLineEdit()
+        self.lineedit_bot_token.setPlaceholderText("xoxb-...")
+        self.lineedit_bot_token.setEchoMode(QLineEdit.Password)
+        api_layout.addRow("Bot Token:", self.lineedit_bot_token)
+
+        # Show/hide token button
+        token_buttons = QHBoxLayout()
+        self.btn_show_token = QPushButton("Show")
+        self.btn_show_token.setCheckable(True)
+        self.btn_show_token.setMaximumWidth(60)
+        token_buttons.addWidget(self.btn_show_token)
+        token_buttons.addStretch()
+        api_layout.addRow("", token_buttons)
+
+        # Channel ID
+        self.lineedit_channel_id = QLineEdit()
+        self.lineedit_channel_id.setPlaceholderText("C0123456789")
+        api_layout.addRow("Channel ID:", self.lineedit_channel_id)
+
+        # Test button
+        self.btn_test = QPushButton("Test Connection")
+        api_layout.addRow("", self.btn_test)
+
+        # Help text
+        help_label = QLabel(
+            "<small>Get Bot Token from your Slack App settings.<br>"
+            "Channel ID: Right-click channel > View channel details > Copy ID</small>"
+        )
+        help_label.setWordWrap(True)
+        help_label.setStyleSheet("color: gray;")
+        api_layout.addRow(help_label)
+
+        api_group.setLayout(api_layout)
+        layout.addWidget(api_group)
+
+        # Notification settings section
+        notif_group = QGroupBox("Notification Settings")
+        notif_layout = QVBoxLayout()
+
+        self.checkbox_notify_error = QCheckBox("Notify on errors")
+        self.checkbox_notify_error.setToolTip("Send a Slack message when an error occurs during acquisition")
+        notif_layout.addWidget(self.checkbox_notify_error)
+
+        self.checkbox_notify_timepoint = QCheckBox("Notify on timepoint completion")
+        self.checkbox_notify_timepoint.setToolTip("Send a Slack message after each timepoint completes")
+        notif_layout.addWidget(self.checkbox_notify_timepoint)
+
+        self.checkbox_send_mosaic = QCheckBox("Include mosaic snapshots")
+        self.checkbox_send_mosaic.setToolTip("Upload mosaic screenshot with timepoint notifications")
+        notif_layout.addWidget(self.checkbox_send_mosaic)
+
+        self.checkbox_notify_start = QCheckBox("Notify on acquisition start")
+        self.checkbox_notify_start.setToolTip("Send a Slack message when an acquisition begins")
+        notif_layout.addWidget(self.checkbox_notify_start)
+
+        self.checkbox_notify_finished = QCheckBox("Notify on acquisition finished")
+        self.checkbox_notify_finished.setToolTip("Send a Slack message when an acquisition completes")
+        notif_layout.addWidget(self.checkbox_notify_finished)
+
+        notif_group.setLayout(notif_layout)
+        layout.addWidget(notif_group)
+
+        # Status label
+        self.label_status = QLabel("")
+        self.label_status.setStyleSheet("color: gray;")
+        layout.addWidget(self.label_status)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        self.btn_save = QPushButton("Save")
+        self.btn_close = QPushButton("Close")
+        button_layout.addStretch()
+        button_layout.addWidget(self.btn_save)
+        button_layout.addWidget(self.btn_close)
+        layout.addLayout(button_layout)
+
+    def _connect_signals(self):
+        """Connect UI signals to handlers."""
+        self.btn_show_token.toggled.connect(self._toggle_token_visibility)
+        self.btn_test.clicked.connect(self._test_connection)
+        self.btn_save.clicked.connect(self._save_settings)
+        self.btn_close.clicked.connect(self.close)
+
+        # Enable/disable controls based on enabled checkbox
+        self.checkbox_enabled.toggled.connect(self._update_controls_state)
+
+    def _toggle_token_visibility(self, show: bool):
+        """Toggle visibility of the bot token."""
+        if show:
+            self.lineedit_bot_token.setEchoMode(QLineEdit.Normal)
+            self.btn_show_token.setText("Hide")
+        else:
+            self.lineedit_bot_token.setEchoMode(QLineEdit.Password)
+            self.btn_show_token.setText("Show")
+
+    def _update_controls_state(self, enabled: bool):
+        """Update the enabled state of notification controls."""
+        self.lineedit_bot_token.setEnabled(enabled)
+        self.lineedit_channel_id.setEnabled(enabled)
+        self.btn_show_token.setEnabled(enabled)
+        self.btn_test.setEnabled(enabled)
+        self.checkbox_notify_error.setEnabled(enabled)
+        self.checkbox_notify_timepoint.setEnabled(enabled)
+        self.checkbox_send_mosaic.setEnabled(enabled)
+        self.checkbox_notify_start.setEnabled(enabled)
+        self.checkbox_notify_finished.setEnabled(enabled)
+
+    def _load_settings(self):
+        """Load settings from cache file or use defaults from _def."""
+        # Start with values from _def
+        self.checkbox_enabled.setChecked(control._def.SlackNotifications.ENABLED)
+        bot_token = control._def.SlackNotifications.BOT_TOKEN or ""
+        channel_id = control._def.SlackNotifications.CHANNEL_ID or ""
+        self.lineedit_bot_token.setText(bot_token)
+        self.lineedit_channel_id.setText(channel_id)
+        self.checkbox_notify_error.setChecked(control._def.SlackNotifications.NOTIFY_ON_ERROR)
+        self.checkbox_notify_timepoint.setChecked(control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE)
+        self.checkbox_send_mosaic.setChecked(control._def.SlackNotifications.SEND_MOSAIC_SNAPSHOTS)
+        self.checkbox_notify_start.setChecked(control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_START)
+        self.checkbox_notify_finished.setChecked(control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_FINISHED)
+
+        # Override with cache file if it exists
+        try:
+            if os.path.exists(CACHE_FILE):
+                with open(CACHE_FILE, "r") as f:
+                    cached = yaml.safe_load(f)
+                if "enabled" in cached:
+                    self.checkbox_enabled.setChecked(cached["enabled"])
+                if "bot_token" in cached and cached["bot_token"]:
+                    self.lineedit_bot_token.setText(cached["bot_token"])
+                if "channel_id" in cached and cached["channel_id"]:
+                    self.lineedit_channel_id.setText(cached["channel_id"])
+                if "notify_on_error" in cached:
+                    self.checkbox_notify_error.setChecked(cached["notify_on_error"])
+                if "notify_on_timepoint_complete" in cached:
+                    self.checkbox_notify_timepoint.setChecked(cached["notify_on_timepoint_complete"])
+                if "send_mosaic_snapshots" in cached:
+                    self.checkbox_send_mosaic.setChecked(cached["send_mosaic_snapshots"])
+                if "notify_on_acquisition_start" in cached:
+                    self.checkbox_notify_start.setChecked(cached["notify_on_acquisition_start"])
+                if "notify_on_acquisition_finished" in cached:
+                    self.checkbox_notify_finished.setChecked(cached["notify_on_acquisition_finished"])
+                log.info("Loaded Slack settings from cache")
+        except Exception as e:
+            log.warning(f"Failed to load Slack settings from cache: {e}")
+
+        self._update_controls_state(self.checkbox_enabled.isChecked())
+
+    def _save_settings(self):
+        """Save settings to cache file and update runtime config."""
+        bot_token = self.lineedit_bot_token.text().strip() or None
+        channel_id = self.lineedit_channel_id.text().strip() or None
+
+        # Update runtime config
+        control._def.SlackNotifications.ENABLED = self.checkbox_enabled.isChecked()
+        control._def.SlackNotifications.BOT_TOKEN = bot_token
+        control._def.SlackNotifications.CHANNEL_ID = channel_id
+        control._def.SlackNotifications.NOTIFY_ON_ERROR = self.checkbox_notify_error.isChecked()
+        control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE = self.checkbox_notify_timepoint.isChecked()
+        control._def.SlackNotifications.SEND_MOSAIC_SNAPSHOTS = self.checkbox_send_mosaic.isChecked()
+        control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_START = self.checkbox_notify_start.isChecked()
+        control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_FINISHED = self.checkbox_notify_finished.isChecked()
+
+        # Update notifier if available
+        if self._slack_notifier:
+            self._slack_notifier.bot_token = bot_token
+            self._slack_notifier.channel_id = channel_id
+
+        # Save to cache file
+        settings = {
+            "enabled": self.checkbox_enabled.isChecked(),
+            "bot_token": bot_token,
+            "channel_id": channel_id,
+            "notify_on_error": self.checkbox_notify_error.isChecked(),
+            "notify_on_timepoint_complete": self.checkbox_notify_timepoint.isChecked(),
+            "send_mosaic_snapshots": self.checkbox_send_mosaic.isChecked(),
+            "notify_on_acquisition_start": self.checkbox_notify_start.isChecked(),
+            "notify_on_acquisition_finished": self.checkbox_notify_finished.isChecked(),
+        }
+
+        try:
+            os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
+            with open(CACHE_FILE, "w") as f:
+                yaml.dump(settings, f, default_flow_style=False)
+            self.label_status.setText("Settings saved")
+            self.label_status.setStyleSheet("color: green;")
+            log.info("Slack settings saved to cache")
+        except Exception as e:
+            self.label_status.setText(f"Failed to save: {e}")
+            self.label_status.setStyleSheet("color: red;")
+            log.error(f"Failed to save Slack settings: {e}")
+
+        self.settings_changed.emit()
+
+    def _test_connection(self):
+        """Test the Slack API connection."""
+        bot_token = self.lineedit_bot_token.text().strip()
+        channel_id = self.lineedit_channel_id.text().strip()
+
+        if not bot_token:
+            QMessageBox.warning(self, "Test Failed", "Please enter a Bot Token")
+            return
+        if not channel_id:
+            QMessageBox.warning(self, "Test Failed", "Please enter a Channel ID")
+            return
+
+        # Temporarily create a notifier or use existing one
+        if self._slack_notifier:
+            # Temporarily set the credentials for testing
+            old_token = self._slack_notifier.bot_token
+            old_channel = self._slack_notifier.channel_id
+            self._slack_notifier.bot_token = bot_token
+            self._slack_notifier.channel_id = channel_id
+            old_enabled = control._def.SlackNotifications.ENABLED
+            control._def.SlackNotifications.ENABLED = True
+
+            success, message = self._slack_notifier.test_connection()
+
+            # Restore original values
+            self._slack_notifier.bot_token = old_token
+            self._slack_notifier.channel_id = old_channel
+            control._def.SlackNotifications.ENABLED = old_enabled
+        else:
+            # Create temporary notifier
+            temp_notifier = SlackNotifier(bot_token=bot_token, channel_id=channel_id)
+            old_enabled = control._def.SlackNotifications.ENABLED
+            control._def.SlackNotifications.ENABLED = True
+
+            success, message = temp_notifier.test_connection()
+            temp_notifier.close()
+
+            control._def.SlackNotifications.ENABLED = old_enabled
+
+        if success:
+            self.label_status.setText("Test successful!")
+            self.label_status.setStyleSheet("color: green;")
+            QMessageBox.information(self, "Test Successful", "Slack API connection successful!")
+        else:
+            self.label_status.setText(f"Test failed: {message}")
+            self.label_status.setStyleSheet("color: red;")
+            QMessageBox.warning(self, "Test Failed", f"Connection failed: {message}")
+
+    def set_slack_notifier(self, notifier: SlackNotifier):
+        """Set the Slack notifier instance."""
+        self._slack_notifier = notifier
+
+
+def load_slack_settings_from_cache():
+    """Load Slack settings from cache file into runtime config.
+
+    This should be called during application startup to restore
+    user preferences from the cache file.
+    """
+    try:
+        if os.path.exists(CACHE_FILE):
+            with open(CACHE_FILE, "r") as f:
+                cached = yaml.safe_load(f)
+            if "enabled" in cached:
+                control._def.SlackNotifications.ENABLED = cached["enabled"]
+            if "bot_token" in cached:
+                control._def.SlackNotifications.BOT_TOKEN = cached["bot_token"]
+            if "channel_id" in cached:
+                control._def.SlackNotifications.CHANNEL_ID = cached["channel_id"]
+            if "notify_on_error" in cached:
+                control._def.SlackNotifications.NOTIFY_ON_ERROR = cached["notify_on_error"]
+            if "notify_on_timepoint_complete" in cached:
+                control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE = cached["notify_on_timepoint_complete"]
+            if "send_mosaic_snapshots" in cached:
+                control._def.SlackNotifications.SEND_MOSAIC_SNAPSHOTS = cached["send_mosaic_snapshots"]
+            if "notify_on_acquisition_start" in cached:
+                control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_START = cached["notify_on_acquisition_start"]
+            if "notify_on_acquisition_finished" in cached:
+                control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_FINISHED = cached[
+                    "notify_on_acquisition_finished"
+                ]
+            log.info("Loaded Slack settings from cache into runtime config")
+    except Exception as e:
+        log.warning(f"Failed to load Slack settings from cache: {e}")

--- a/software/docs/slack_notifications.md
+++ b/software/docs/slack_notifications.md
@@ -1,0 +1,128 @@
+# Slack Notifications for Squid Microscope
+
+Send real-time notifications to Slack during acquisitions, including mosaic screenshots at each timepoint.
+
+## Features
+
+- **Acquisition start** - Notifies when acquisition begins with parameters summary
+- **Timepoint complete** - Sends mosaic screenshot with stats (elapsed time, remaining time, images, FOVs, laser AF results)
+- **Acquisition finished** - Summary with total images, duration, and error count
+- **Error notifications** - Alerts when job failures occur during acquisition
+
+## Setup
+
+### 1. Create a Slack App
+
+1. Go to https://api.slack.com/apps
+2. Click **"Create New App"** → **"From scratch"**
+3. Name your app (e.g., "Squid Microscope") and select your workspace
+4. Click **"Create App"**
+
+### 2. Configure Bot Permissions
+
+1. In the left sidebar, click **"OAuth & Permissions"**
+2. Scroll to **"Scopes"** → **"Bot Token Scopes"**
+3. Add these scopes:
+   - `chat:write` - Send messages
+   - `files:write` - Upload mosaic images
+
+### 3. Install App to Workspace
+
+1. Scroll up to **"OAuth Tokens for Your Workspace"**
+2. Click **"Install to Workspace"**
+3. Review and click **"Allow"**
+4. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+
+### 4. Get Channel ID
+
+1. In Slack, right-click the channel for notifications
+2. Select **"View channel details"**
+3. Copy the **Channel ID** at the bottom (starts with `C`)
+
+> **Note:** You must use a channel ID (starts with `C`, `G`, `D`, or `Z`), not a user ID. Direct messages to yourself won't work for image uploads.
+
+### 5. Invite Bot to Channel
+
+In the channel, type:
+```
+/invite @YourBotName
+```
+
+### 6. Configure in Squid
+
+1. Open **Settings → Slack Notifications**
+2. Check **"Enable Slack Notifications"**
+3. Enter the **Bot Token** (`xoxb-...`)
+4. Enter the **Channel ID** (`C...`)
+5. Click **"Test Connection"** to verify
+6. Configure which notifications to receive
+7. Click **"Save"**
+
+## Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| Enable Slack Notifications | Master switch for all notifications |
+| Notify on errors | Send alert when job fails during acquisition |
+| Notify on timepoint completion | Send message + mosaic after each timepoint |
+| Include mosaic snapshots | Attach screenshot with timepoint notifications |
+| Notify on acquisition start | Send message when acquisition begins |
+| Notify on acquisition finished | Send summary when acquisition completes |
+
+## Notification Examples
+
+### Timepoint Complete
+```
+Timepoint 5/10 Complete
+
+Elapsed: 2h 15m
+Remaining: ~2h 30m
+Images: 1,234
+FOVs: 412
+Laser AF: 408/412 FOVs succeeded (4 failed)
+
+[Mosaic screenshot attached]
+```
+
+### Acquisition Complete
+```
+Acquisition Complete
+
+Experiment: 2024-01-22_14-30-00
+Status: Finished successfully
+Total Images: 12,340
+Timepoints: 10
+Duration: 4h 45m
+```
+
+## Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| `not_in_channel` | Invite the bot to the channel with `/invite @BotName` |
+| `invalid_auth` | Check that the bot token is correct |
+| `channel_not_found` | Verify the channel ID (must start with C, G, D, or Z) |
+| `missing_scope` | Add required scopes and reinstall the app |
+| No image uploads | Ensure `files:write` scope is added; use a channel, not DM |
+
+## INI Configuration
+
+Settings can also be configured in the INI file:
+
+```ini
+[SLACK]
+enabled = False
+notify_on_error = True
+notify_on_timepoint_complete = True
+notify_on_acquisition_start = False
+notify_on_acquisition_finished = True
+send_mosaic_snapshots = True
+```
+
+> **Note:** Bot Token and Channel ID are stored in a local cache file (`cache/slack_settings.yaml`) for security and are not saved to the INI file.
+
+## Settings Persistence
+
+- Settings are saved to `cache/slack_settings.yaml`
+- Changes take effect immediately without restart
+- Settings dialog can remain open during acquisition for live toggling

--- a/software/tests/control/test_slack_notifier.py
+++ b/software/tests/control/test_slack_notifier.py
@@ -1,0 +1,393 @@
+"""Unit tests for the Slack notification system.
+
+These tests verify the SlackNotifier class functionality including:
+- Message queuing and dispatch
+- Error notification throttling
+- Timepoint and acquisition notifications
+- Image conversion
+- Webhook communication
+"""
+
+import json
+import queue
+import time
+import urllib.error
+import urllib.request
+from unittest import mock
+
+import numpy as np
+import pytest
+
+# Import with config handling - skip if configuration not available
+try:
+    import control._def
+    from control.slack_notifier import (
+        SlackNotifier,
+        TimepointStats,
+        AcquisitionStats,
+    )
+
+    SLACK_NOTIFIER_AVAILABLE = True
+except (SystemExit, Exception):
+    SLACK_NOTIFIER_AVAILABLE = False
+    SlackNotifier = None
+    TimepointStats = None
+    AcquisitionStats = None
+
+
+pytestmark = pytest.mark.skipif(
+    not SLACK_NOTIFIER_AVAILABLE, reason="SlackNotifier not available (configuration not loaded)"
+)
+
+
+@pytest.fixture
+def notifier():
+    """Create a SlackNotifier instance for testing."""
+    # Enable notifications and set a test webhook URL
+    control._def.SlackNotifications.ENABLED = True
+    control._def.SlackNotifications.WEBHOOK_URL = "https://hooks.slack.com/test"
+    control._def.SlackNotifications.NOTIFY_ON_ERROR = True
+    control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE = True
+    control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_START = True
+    control._def.SlackNotifications.NOTIFY_ON_ACQUISITION_FINISHED = True
+    control._def.SlackNotifications.SEND_MOSAIC_SNAPSHOTS = True
+
+    notifier = SlackNotifier()
+    yield notifier
+    notifier.close()
+
+
+@pytest.fixture
+def disabled_notifier():
+    """Create a disabled SlackNotifier instance for testing."""
+    control._def.SlackNotifications.ENABLED = False
+    notifier = SlackNotifier()
+    yield notifier
+    notifier.close()
+
+
+class TestSlackNotifierInit:
+    """Tests for SlackNotifier initialization."""
+
+    def test_init_creates_worker_thread(self, notifier):
+        """Test that initialization starts a worker thread."""
+        assert notifier._worker_thread is not None
+        assert notifier._worker_thread.is_alive()
+
+    def test_init_with_custom_webhook_url(self):
+        """Test initialization with a custom webhook URL."""
+        custom_url = "https://custom.webhook.url"
+        notifier = SlackNotifier(webhook_url=custom_url)
+        assert notifier.webhook_url == custom_url
+        notifier.close()
+
+    def test_webhook_url_property_prefers_instance_value(self):
+        """Test that instance webhook URL takes precedence over config."""
+        control._def.SlackNotifications.WEBHOOK_URL = "https://config.url"
+        notifier = SlackNotifier(webhook_url="https://instance.url")
+        assert notifier.webhook_url == "https://instance.url"
+        notifier.close()
+
+    def test_enabled_property_checks_both_flags(self):
+        """Test that enabled requires both ENABLED flag and webhook URL."""
+        control._def.SlackNotifications.ENABLED = True
+        control._def.SlackNotifications.WEBHOOK_URL = "https://test.url"
+        notifier = SlackNotifier()
+        assert notifier.enabled is True
+        notifier.close()
+
+        control._def.SlackNotifications.ENABLED = False
+        notifier = SlackNotifier()
+        assert notifier.enabled is False
+        notifier.close()
+
+        control._def.SlackNotifications.ENABLED = True
+        control._def.SlackNotifications.WEBHOOK_URL = None
+        notifier = SlackNotifier()
+        assert notifier.enabled is False
+        notifier.close()
+
+
+class TestSlackNotifierMessages:
+    """Tests for message sending functionality."""
+
+    def test_send_message_queues_payload(self, notifier):
+        """Test that send_message adds payload to queue."""
+        with mock.patch.object(notifier, "_queue_message") as mock_queue:
+            notifier.send_message("Test message")
+            mock_queue.assert_called_once()
+            args = mock_queue.call_args[0][0]
+            assert args["text"] == "Test message"
+
+    def test_send_message_with_blocks(self, notifier):
+        """Test that send_message includes blocks in payload."""
+        blocks = [{"type": "section", "text": {"type": "plain_text", "text": "Test"}}]
+        with mock.patch.object(notifier, "_queue_message") as mock_queue:
+            notifier.send_message("Test message", blocks=blocks)
+            args = mock_queue.call_args[0][0]
+            assert args["blocks"] == blocks
+
+    def test_queue_message_respects_disabled_state(self, disabled_notifier):
+        """Test that queue_message does nothing when disabled."""
+        disabled_notifier._message_queue = mock.MagicMock()
+        disabled_notifier._queue_message({"text": "test"})
+        disabled_notifier._message_queue.put_nowait.assert_not_called()
+
+
+class TestSlackNotifierErrorNotifications:
+    """Tests for error notification functionality."""
+
+    def test_notify_error_sends_message(self, notifier):
+        """Test that notify_error sends a formatted error message."""
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_error("Test error", {"region": "A1", "fov": 3})
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            assert "Test error" in args[0][0]
+
+    def test_notify_error_throttling(self, notifier):
+        """Test that repeated errors are throttled."""
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            # First call should go through
+            notifier.notify_error("Same error")
+            assert mock_send.call_count == 1
+
+            # Immediate second call should be throttled
+            notifier.notify_error("Same error")
+            assert mock_send.call_count == 1
+
+    def test_notify_error_respects_flag(self):
+        """Test that notify_error respects NOTIFY_ON_ERROR flag."""
+        control._def.SlackNotifications.ENABLED = True
+        control._def.SlackNotifications.WEBHOOK_URL = "https://test.url"
+        control._def.SlackNotifications.NOTIFY_ON_ERROR = False
+
+        notifier = SlackNotifier()
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_error("Test error")
+            mock_send.assert_not_called()
+        notifier.close()
+
+
+class TestSlackNotifierTimepointNotifications:
+    """Tests for timepoint notification functionality."""
+
+    def test_notify_timepoint_complete_sends_message(self, notifier):
+        """Test that notify_timepoint_complete sends a formatted message."""
+        stats = TimepointStats(
+            timepoint=5,
+            total_timepoints=10,
+            elapsed_seconds=3600,
+            estimated_remaining_seconds=3600,
+            images_captured=1000,
+            fovs_captured=100,
+            laser_af_successes=95,
+            laser_af_failures=5,
+            laser_af_failure_reasons=[],
+        )
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_timepoint_complete(stats)
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            assert "5/10" in args[0][0]
+
+    def test_notify_timepoint_respects_flag(self):
+        """Test that notify_timepoint_complete respects flag."""
+        control._def.SlackNotifications.ENABLED = True
+        control._def.SlackNotifications.WEBHOOK_URL = "https://test.url"
+        control._def.SlackNotifications.NOTIFY_ON_TIMEPOINT_COMPLETE = False
+
+        notifier = SlackNotifier()
+        stats = TimepointStats(
+            timepoint=1,
+            total_timepoints=10,
+            elapsed_seconds=60,
+            estimated_remaining_seconds=540,
+            images_captured=100,
+            fovs_captured=10,
+            laser_af_successes=10,
+            laser_af_failures=0,
+            laser_af_failure_reasons=[],
+        )
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_timepoint_complete(stats)
+            mock_send.assert_not_called()
+        notifier.close()
+
+
+class TestSlackNotifierAcquisitionNotifications:
+    """Tests for acquisition start/finish notifications."""
+
+    def test_notify_acquisition_start_sends_message(self, notifier):
+        """Test that notify_acquisition_start sends a formatted message."""
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_acquisition_start(
+                experiment_id="test_exp",
+                num_regions=5,
+                num_timepoints=10,
+                num_channels=3,
+                num_z_levels=5,
+            )
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            assert "test_exp" in args[0][0]
+
+    def test_notify_acquisition_finished_sends_message(self, notifier):
+        """Test that notify_acquisition_finished sends a formatted message."""
+        stats = AcquisitionStats(
+            total_images=5000,
+            total_timepoints=10,
+            total_duration_seconds=7200,
+            errors_encountered=2,
+            experiment_id="test_exp",
+        )
+        with mock.patch.object(notifier, "send_message") as mock_send:
+            notifier.notify_acquisition_finished(stats)
+            mock_send.assert_called_once()
+            args = mock_send.call_args
+            assert "test_exp" in args[0][0]
+
+
+class TestSlackNotifierTimeEstimation:
+    """Tests for time estimation functionality."""
+
+    def test_record_timepoint_duration(self, notifier):
+        """Test recording timepoint durations."""
+        notifier.record_timepoint_duration(60.0)
+        notifier.record_timepoint_duration(65.0)
+        assert len(notifier._timepoint_durations) == 2
+
+    def test_estimate_remaining_time(self, notifier):
+        """Test remaining time estimation."""
+        notifier.record_timepoint_duration(60.0)
+        notifier.record_timepoint_duration(60.0)
+
+        # After 2 timepoints of 10 total, 8 remaining at 60s each
+        remaining = notifier.estimate_remaining_time(2, 10)
+        assert remaining == 480.0  # 8 * 60
+
+    def test_estimate_remaining_time_no_data(self, notifier):
+        """Test remaining time estimation with no data."""
+        remaining = notifier.estimate_remaining_time(1, 10)
+        assert remaining == 0.0
+
+
+class TestSlackNotifierFormatting:
+    """Tests for duration formatting."""
+
+    def test_format_duration_seconds(self, notifier):
+        """Test formatting durations under a minute."""
+        assert notifier._format_duration(30) == "30s"
+        assert notifier._format_duration(59) == "59s"
+
+    def test_format_duration_minutes(self, notifier):
+        """Test formatting durations in minutes."""
+        assert notifier._format_duration(60) == "1m"
+        assert notifier._format_duration(3599) == "60m"
+
+    def test_format_duration_hours(self, notifier):
+        """Test formatting durations in hours."""
+        assert notifier._format_duration(3600) == "1h 0m"
+        assert notifier._format_duration(7200) == "2h 0m"
+        assert notifier._format_duration(5400) == "1h 30m"
+
+
+class TestSlackNotifierImageConversion:
+    """Tests for image conversion functionality."""
+
+    def test_image_to_png_bytes_uint8(self, notifier):
+        """Test converting uint8 image to PNG bytes."""
+        image = np.zeros((100, 100), dtype=np.uint8)
+        image[40:60, 40:60] = 255
+
+        png_bytes = notifier._image_to_png_bytes(image)
+        assert len(png_bytes) > 0
+        # PNG files start with specific magic bytes
+        assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_image_to_png_bytes_uint16(self, notifier):
+        """Test converting uint16 image to PNG bytes."""
+        image = np.zeros((100, 100), dtype=np.uint16)
+        image[40:60, 40:60] = 65535
+
+        png_bytes = notifier._image_to_png_bytes(image)
+        assert len(png_bytes) > 0
+        assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_image_to_png_bytes_large_image_resize(self, notifier):
+        """Test that large images are resized."""
+        # Create an image larger than MAX_IMAGE_SIZE
+        large_size = notifier.MAX_IMAGE_SIZE * 2
+        image = np.zeros((large_size, large_size), dtype=np.uint8)
+
+        png_bytes = notifier._image_to_png_bytes(image)
+        assert len(png_bytes) > 0
+
+
+class TestSlackNotifierWebhook:
+    """Tests for webhook communication."""
+
+    def test_send_to_slack_success(self, notifier):
+        """Test successful webhook post."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", return_value=mock_response):
+            result = notifier._send_to_slack({"text": "test"})
+            assert result is True
+
+    def test_send_to_slack_failure(self, notifier):
+        """Test handling webhook failure."""
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("Connection failed"),
+        ):
+            result = notifier._send_to_slack({"text": "test"})
+            assert result is False
+
+    def test_send_to_slack_no_url(self, notifier):
+        """Test that sending fails gracefully with no URL."""
+        notifier._webhook_url = None
+        control._def.SlackNotifications.WEBHOOK_URL = None
+        result = notifier._send_to_slack({"text": "test"})
+        assert result is False
+
+
+class TestSlackNotifierTestConnection:
+    """Tests for connection testing."""
+
+    def test_test_connection_success(self, notifier):
+        """Test successful connection test."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", return_value=mock_response):
+            success, message = notifier.test_connection()
+            assert success is True
+            assert "successful" in message.lower()
+
+    def test_test_connection_no_url(self):
+        """Test connection test with no URL."""
+        control._def.SlackNotifications.ENABLED = True
+        control._def.SlackNotifications.WEBHOOK_URL = None
+        notifier = SlackNotifier()
+        success, message = notifier.test_connection()
+        assert success is False
+        assert "no webhook url" in message.lower()
+        notifier.close()
+
+
+class TestSlackNotifierClose:
+    """Tests for cleanup functionality."""
+
+    def test_close_stops_worker_thread(self, notifier):
+        """Test that close() stops the worker thread."""
+        assert notifier._worker_thread.is_alive()
+        notifier.close()
+        # Give thread time to stop
+        time.sleep(0.5)
+        assert not notifier._worker_thread.is_alive()


### PR DESCRIPTION
## Summary

- Add real-time Slack notifications during acquisitions (start, timepoint complete, finished, errors)
- Send mosaic screenshots with timepoint notifications via Slack Bot API
- Track laser AF success/failure stats in notifications
- Add Settings dialog (Settings → Slack Notifications) for configuration
- Store settings in YAML cache file (`cache/slack_settings.yaml`)

## Setup

See `docs/slack_notifications.md` for full setup instructions:
1. Create a Slack App with `chat:write` and `files:write` scopes
2. Install to workspace and get Bot Token (`xoxb-...`)
3. Get Channel ID from channel details
4. Configure in Settings → Slack Notifications

## Test plan

- [x] Test in simulation mode with Slack workspace
- [x] Verify timepoint notifications with mosaic screenshots
- [x] Verify acquisition start/finish notifications
- [x] Verify settings persistence across restarts
- [ ] Test error notifications (requires triggering job failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)