### PR TITLE
fix: suppress Pydantic serializer int/float warning in LaserAFConfig

### DIFF
--- a/software/control/core/config/repository.py
+++ b/software/control/core/config/repository.py
@@ -159,7 +159,7 @@ class ConfigRepository:
 
             # Convert model to dict, using mode="json" to ensure Enums are serialized as strings
             # exclude_none=True omits optional fields when None (cleaner YAML files)
-            data = model.model_dump(exclude_none=True, mode="json")
+            data = model.model_dump(exclude_none=True, mode="json", warnings=False)
 
             with open(path, "w") as f:
                 yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -96,7 +96,7 @@ class LaserAutofocusController(QObject):
 
         # Update cache if objective store and profile is available
         if self.objectiveStore and self._current_profile and self.objectiveStore.current_objective:
-            updated_config = LaserAFConfig(**config.model_dump())
+            updated_config = LaserAFConfig(**config.model_dump(warnings=False))
             self._config_repo.save_laser_af_config(
                 self._current_profile, self.objectiveStore.current_objective, updated_config
             )


### PR DESCRIPTION
## Summary
- Add `warnings=False` to two `model_dump()` calls that serialize `LaserAFConfig`
- Suppresses the harmless "Expected `int` but got `float`" Pydantic serializer warning that appears during laser autofocus initialization
- Root cause: `model_copy()` bypasses Pydantic validation, allowing float values in int-typed fields. The values round-trip correctly (coerced back to int on reload).

## Test plan
- [x] Verified `model_dump(warnings=False)` suppresses the warning
- [x] Verified existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)