### PR TITLE
fix: detect JobRunner subprocess death and stop memory-profiler ESRCH spam

### DIFF
--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1,12 +1,14 @@
 import abc
 import multiprocessing
+import multiprocessing.connection
 import queue
 import os
+import threading
 import time
 import json
 from datetime import datetime
 from contextlib import contextmanager
-from typing import ClassVar, Dict, Generic, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Callable, ClassVar, Dict, Generic, List, Optional, Set, Tuple, TypeVar, Union
 from uuid import uuid4
 
 from dataclasses import dataclass, field
@@ -1064,12 +1066,63 @@ class JobRunner(multiprocessing.Process):
         self._bp_pending_bytes = bp_pending_bytes
         self._bp_capacity_event = bp_capacity_event
 
+        # Watchdog for detecting unexpected subprocess death (segfault, OOM kill, etc.).
+        # Without this, a dead JobRunner silently rots the acquisition: the parent keeps
+        # queuing save jobs that no one consumes.
+        self._on_unexpected_exit: Optional[Callable[[Optional[int]], None]] = None
+        self._watchdog: Optional[threading.Thread] = None
+
         # Clean up stale metadata files from previous crashed acquisitions
         # Only run when explicitly requested (i.e., when OME-TIFF saving is being used)
         if cleanup_stale_ome_files:
             removed = ome_tiff_writer.cleanup_stale_metadata_files()
             if removed:
                 self._log.info(f"Cleaned up {len(removed)} stale OME-TIFF metadata files")
+
+    def set_unexpected_exit_handler(self, handler: Optional[Callable[[Optional[int]], None]]) -> None:
+        """Register a callback to invoke if the subprocess dies without a clean shutdown.
+
+        The handler is called from the watchdog thread with the subprocess exitcode
+        (which may be None, a positive int, or a negative signal number on POSIX).
+        """
+        self._on_unexpected_exit = handler
+
+    def start(self):
+        super().start()
+        # Watchdog must start after super().start() so self.pid and self.sentinel are set.
+        self._watchdog = threading.Thread(
+            target=self._watch_subprocess,
+            daemon=True,
+            name=f"JobRunner-watchdog[{self.pid}]",
+        )
+        self._watchdog.start()
+
+    def kill(self):
+        # Mark as expected so the watchdog treats the exit as intentional.
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        super().kill()
+
+    def _watch_subprocess(self) -> None:
+        """Block until the subprocess exits, then distinguish expected vs. unexpected death."""
+        # Capture references; shutdown() clears self._shutdown_event after join().
+        shutdown_event = self._shutdown_event
+        pid = self.pid
+        multiprocessing.connection.wait([self.sentinel])
+        exitcode = self.exitcode
+        if shutdown_event is not None and shutdown_event.is_set():
+            self._log.info(f"JobRunner PID={pid} exited cleanly (exitcode={exitcode})")
+            return
+        self._log.error(
+            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). "
+            f"Pending save jobs will not complete."
+        )
+        handler = self._on_unexpected_exit
+        if handler is not None:
+            try:
+                handler(exitcode)
+            except Exception:
+                self._log.exception("JobRunner unexpected-exit handler raised")
 
     def dispatch(self, job: Job):
         # Inject acquisition_info into SaveOMETiffJob instances before serialization.

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1114,8 +1114,7 @@ class JobRunner(multiprocessing.Process):
             self._log.info(f"JobRunner PID={pid} exited cleanly (exitcode={exitcode})")
             return
         self._log.error(
-            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). "
-            f"Pending save jobs will not complete."
+            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). " f"Pending save jobs will not complete."
         )
         handler = self._on_unexpected_exit
         if handler is not None:

--- a/software/control/core/memory_profiler.py
+++ b/software/control/core/memory_profiler.py
@@ -259,7 +259,9 @@ def _get_linux_pss_mb(pid: int) -> float:
                     pss_total_kb += int(parts[1])
 
         return pss_total_kb / 1024
-    except (FileNotFoundError, PermissionError, ValueError):
+    except (FileNotFoundError, PermissionError, ValueError, ProcessLookupError):
+        # ProcessLookupError (errno ESRCH) can occur when the process exited between
+        # PID enumeration and the smaps_rollup read, or when the PID is a zombie.
         pass
     return 0.0
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -377,9 +377,7 @@ class MultiPointWorker:
 
     def _on_job_runner_died(self, exitcode: Optional[int]) -> None:
         """Invoked by JobRunner's watchdog when a subprocess dies unexpectedly."""
-        self._log.error(
-            f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition."
-        )
+        self._log.error(f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition.")
         self._acquisition_error_count += 1
         self.request_abort_fn()
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -370,8 +370,18 @@ class MultiPointWorker:
                     # Subprocess starts warming up in background - don't block here
 
             self._job_runners.append((job_class, job_runner))
+            if job_runner is not None:
+                job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
         self._abort_on_failed_job = abort_on_failed_jobs
         self._first_job_dispatched = False  # Track if we've waited for subprocess warmup
+
+    def _on_job_runner_died(self, exitcode: Optional[int]) -> None:
+        """Invoked by JobRunner's watchdog when a subprocess dies unexpectedly."""
+        self._log.error(
+            f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition."
+        )
+        self._acquisition_error_count += 1
+        self.request_abort_fn()
 
     def update_use_piezo(self, value):
         self.use_piezo = value


### PR DESCRIPTION
## Summary

- Add a watchdog thread to `JobRunner` that detects unexpected subprocess death (segfault, SIGKILL, OOM) via `Process.sentinel` and invokes a handler; `MultiPointWorker` wires this to `request_abort_fn()` so the acquisition stops within one timepoint check instead of silently queuing saves into a dead worker for hours.
- Catch `ProcessLookupError` in `_get_linux_pss_mb` alongside `FileNotFoundError`/`PermissionError`/`ValueError`, so reading `/proc/<zombie>/smaps_rollup` no longer produces a WARNING + traceback on every sample.

## Background

In a 48-hour run on a workstation the JobRunner subprocess segfaulted at the 9-hour mark in `libnvidia-glcore.so` (inherited via `fork()` from the Qt/OpenGL parent). The parent never noticed: `/proc/<pid>` still enumerated as a zombie, 465 subsequent timepoint save jobs queued into a queue nothing was consuming, and the UI reported normal completion. The only log signal was ~6,900 memory-profiler ESRCH tracebacks and 466 `Backpressure reset() called with 1 jobs pending` warnings.

These fixes don't address the root cause (fork-unsafety — that's a follow-up to switch `JobRunner` to `spawn`), but they turn a silent multi-hour data-loss failure into a loud, actionable error on the next timepoint.

## Test plan

- [x] `pytest tests/control/core/test_job_runner_shutdown.py tests/control/core/test_job_runner_pending.py tests/control/core/test_backpressure.py` — 63 passed
- [x] `pytest tests/control/core/test_job_processing_downsampled.py tests/control/core/test_drain_all_issue.py` — 13 passed
- [x] `pytest tests/control/core/test_memory_profiler.py` — 56 passed (1 skipped, platform-specific)
- [x] Manual smoke test: `os.kill(runner.pid, SIGKILL)` on a live JobRunner → watchdog fires within milliseconds, handler receives `exitcode=-9` (`-SIGKILL`), ERROR log identifies PID and "died UNEXPECTEDLY"
- [ ] Full acquisition smoke test on hardware (kill runner mid-run in simulation, confirm acquisition aborts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)