### PR TITLE
feat(tucsen): callback-based frame delivery (TUCAM_Buf_DataCallBack)

### DIFF
--- a/software/control/camera_tucsen.py
+++ b/software/control/camera_tucsen.py
@@ -151,19 +151,16 @@ class TucsenCamera(AbstractCamera):
 
         # TODO: Open camera by model (We don't need it for Tucsen camera right now)
 
-        self._read_thread_lock = threading.Lock()
-        self._read_thread: Optional[threading.Thread] = None
-        self._read_thread_keep_running = threading.Event()
-        self._read_thread_keep_running.clear()
-        self._read_thread_wait_period_s = 1.0
-        self._read_thread_running = threading.Event()
-        self._read_thread_running.clear()
-
         self._frame_lock = threading.Lock()
         self._current_frame: Optional[CameraFrame] = None
         self._last_trigger_timestamp = 0
         self._trigger_sent = threading.Event()
         self._is_streaming = threading.Event()
+
+        # TUCam calls this on its own thread when a new frame is ready. Keep the
+        # CFUNCTYPE object alive on the instance: the SDK holds only a borrowed
+        # pointer, and if Python GCs it a later callback jumps into freed memory.
+        self._frame_callback_fn = BUFFER_CALLBACK(self._on_frame_callback)
 
         self._camera = TucsenCamera._open(index=0)
         self._model_properties = self._get_model_properties(self._config.camera_model)
@@ -315,12 +312,17 @@ class TucsenCamera(AbstractCamera):
         if self._m_frame is None:
             self._allocate_buffer()
 
+        # Re-register every cycle: the vendor examples register immediately before
+        # Cap_Start, and it is not documented that a registration survives
+        # Cap_Stop/Cap_Start or the Buf_Release/Buf_Alloc done on binning/ROI changes.
+        if TUCAM_Buf_DataCallBack(self._camera, self._frame_callback_fn, None) != TUCAMRET.TUCAMRET_SUCCESS:
+            TUCAM_Buf_Release(self._camera)
+            raise CameraError("Failed to register frame callback")
+
         trigger_mode = self._capture_mode_genicam if self._model_properties.is_genicam else self._trigger_attr.nTgrMode
         if TUCAM_Cap_Start(self._camera, trigger_mode) != TUCAMRET.TUCAMRET_SUCCESS:
             TUCAM_Buf_Release(self._camera)
             raise CameraError("Failed to start streaming")
-
-        self._ensure_read_thread_running()
 
         self._trigger_sent.clear()
         self._is_streaming.set()
@@ -340,19 +342,28 @@ class TucsenCamera(AbstractCamera):
             self._log.debug("Already stopped, stop_streaming is noop")
             return
 
-        self._cleanup_read_thread()
-
+        # Vendor teardown order (AbortWait then Cap_Stop); AbortWait no longer has a
+        # WaitForFrame loop to break, but keeping the sanctioned sequence is free.
+        if TUCAM_Buf_AbortWait(self._camera) != TUCAMRET.TUCAMRET_SUCCESS:
+            self._log.error("Failed to abort wait for frame")
         if TUCAM_Cap_Stop(self._camera) != TUCAMRET.TUCAMRET_SUCCESS:
             raise CameraError("Failed to stop streaming")
 
-        self._trigger_sent.clear()
         self._is_streaming.clear()
+        self._trigger_sent.clear()
         self._log.info("TUCam Camera streaming stopped")
 
     def get_is_streaming(self):
         return self._is_streaming.is_set()
 
     def close(self):
+        # Quiesce frame delivery before tearing down the handle so a callback can't
+        # fire into a closed camera. Best-effort: a stop failure must not abort the
+        # teardown that follows, or the device handle / SDK would leak.
+        try:
+            self.stop_streaming()
+        except CameraError as e:
+            self._log.error(f"stop_streaming failed during close, continuing teardown: {e}")
         if self.temperature_reading_thread is not None:
             self._terminate_temperature_event.set()
             self.temperature_reading_thread.join()
@@ -361,90 +372,37 @@ class TucsenCamera(AbstractCamera):
         TUCAM_Api_Uninit()
         self._log.info("Close Tucsen camera success")
 
-    def _ensure_read_thread_running(self):
-        with self._read_thread_lock:
-            if self._read_thread is not None and self._read_thread_running.is_set():
-                self._log.debug("Read thread exists and thread is marked as running.")
-                return True
-
-            elif self._read_thread is not None:
-                self._log.warning("Read thread already exists, but not marked as running.  Still attempting start.")
-
-            self._read_thread = threading.Thread(target=self._wait_for_frame, daemon=True)
-            self._read_thread_keep_running.set()
-            self._read_thread.start()
-
-    def _cleanup_read_thread(self):
-        self._log.debug("Cleaning up read thread.")
-        with self._read_thread_lock:
-            if self._read_thread is None:
-                self._log.warning("No read thread, already not running?")
-                return True
-
-            self._read_thread_keep_running.clear()
-
-            if TUCAM_Buf_AbortWait(self._camera) != TUCAMRET.TUCAMRET_SUCCESS:
-                self._log.error("Failed to abort wait for frame")
-
-            self._read_thread.join(1.1 * self._read_thread_wait_period_s)
-
-            success = not self._read_thread.is_alive()
-            if not success:
-                self._log.warning("Read thread refused to exit!")
-
-            self._read_thread = None
-            self._read_thread_running.clear()
-
-    def _wait_for_frame(self):
-        self._log.info("Starting Tucsen read thread.")
-        self._read_thread_running.set()
-        while self._read_thread_keep_running.is_set():
-            try:
-                wait_time_ms = int(self._read_thread_wait_period_s * 1000)  # ms, convert to int
-                try:
-                    TUCAM_Buf_WaitForFrame(self._camera, pointer(self._m_frame), c_int32(wait_time_ms))
-                except Exception:
-                    pass
-
-                if self._m_frame is None or self._m_frame.pBuffer is None or self._m_frame.pBuffer == 0:
-                    self._log.error("Invalid frame buffer")
-                    continue
-
-                np_image = self._convert_frame_to_numpy(self._m_frame)
-
-                processed_frame = self._process_raw_frame(np_image)
-                with self._frame_lock:
-                    camera_frame = CameraFrame(
-                        frame_id=self._current_frame.frame_id + 1 if self._current_frame else 1,
-                        timestamp=time.time(),
-                        frame=processed_frame,
-                        frame_format=self.get_frame_format(),
-                        frame_pixel_format=self.get_pixel_format(),
-                    )
-
-                    self._current_frame = camera_frame
-                self._propogate_frame(camera_frame)
-                self._trigger_sent.clear()
-
-                time.sleep(0.001)
-
-            except Exception as e:
-                self._log.exception(f"Exception: {e} in read loop, ignoring and trying to continue.")
-        self._read_thread_running.clear()
-
-    def _convert_frame_to_numpy(self, frame: TUCAM_FRAME) -> np.ndarray:
-        # TODO: In the latest version of 400BSI V3, the readout data will match the actual bit depth.
-        # We are not able to tell the firmware version from SN yet. Need to figure out if it's safe to assume
-        # all users have the latest firmware. We use 16-bit buffer for the old demo units for now.
-        buf = create_string_buffer(frame.uiImgSize)
-        pointer_data = c_void_p(frame.pBuffer + frame.usHeader)
-        memmove(buf, pointer_data, frame.uiImgSize)
-
-        data = bytes(buf)
-        image_np = np.frombuffer(data, dtype=np.uint16)
-        image_np = image_np.reshape((frame.usHeight, frame.usWidth))
-
-        return image_np
+    def _on_frame_callback(self):
+        # Runs on TUCam's internal thread. BUFFER_CALLBACK is CFUNCTYPE(c_void_p)
+        # with no arguments, so there is no per-call frame pointer: we re-fetch the
+        # just-arrived frame via TUCAM_Buf_GetData using the camera handle.
+        if not self._is_streaming.is_set():
+            return  # cheap early-out for a late callback after stop
+        try:
+            with self._frame_lock:  # serialized vs Buf_Release/Alloc in _update_internal_settings
+                if not self._is_streaming.is_set():
+                    return
+                header = TUCAM_RAWIMG_HEADER()
+                if TUCAM_Buf_GetData(self._camera, pointer(header)) != TUCAMRET.TUCAMRET_SUCCESS:
+                    self._log.error("TUCAM_Buf_GetData failed in frame callback")
+                    return
+                if not header.pImgData or header.uiImgSize == 0:
+                    self._log.error("Invalid frame header (null pImgData / zero size) in callback")
+                    return
+                np_image = self._convert_header_to_numpy(header)
+                camera_frame = CameraFrame(
+                    frame_id=self._current_frame.frame_id + 1 if self._current_frame else 1,
+                    timestamp=time.time(),
+                    frame=self._process_raw_frame(np_image),
+                    frame_format=self.get_frame_format(),
+                    frame_pixel_format=self.get_pixel_format(),
+                )
+                self._current_frame = camera_frame
+            # lock released; np_image/camera_frame are private copies — device memory no longer touched
+            self._propogate_frame(camera_frame)
+            self._trigger_sent.clear()
+        except Exception as e:
+            self._log.exception(f"Exception in Tucsen frame callback: {e}")
 
     @staticmethod
     def _convert_header_to_numpy(header: TUCAM_RAWIMG_HEADER) -> np.ndarray:
@@ -475,10 +433,6 @@ class TucsenCamera(AbstractCamera):
     def read_camera_frame(self) -> Optional[CameraFrame]:
         if not self.get_is_streaming():
             self._log.error("Cannot read camera frame when not streaming.")
-            return None
-
-        if not self._read_thread_running.is_set():
-            self._log.error("Fatal camera error: read thread not running!")
             return None
 
         starting_id = self.get_frame_id()
@@ -585,9 +539,14 @@ class TucsenCamera(AbstractCamera):
         return [CameraPixelFormat.MONO16]
 
     def _update_internal_settings(self):
-        if TUCAM_Buf_Release(self._camera) != TUCAMRET.TUCAMRET_SUCCESS:
-            raise CameraError("Failed to release buffer")
-        self._allocate_buffer()
+        # Hold _frame_lock across the free+realloc so a callback (which holds the
+        # same lock while reading header.pImgData) can never read a freed buffer.
+        # _calculate_strobe_delay stays outside the lock: on genicam models it issues
+        # SDK queries and would needlessly lengthen the held region.
+        with self._frame_lock:
+            if TUCAM_Buf_Release(self._camera) != TUCAMRET.TUCAMRET_SUCCESS:
+                raise CameraError("Failed to release buffer")
+            self._allocate_buffer()
         self._calculate_strobe_delay()
 
     def _raw_set_resolution(self, bin_value: int):

--- a/software/control/camera_tucsen.py
+++ b/software/control/camera_tucsen.py
@@ -446,6 +446,32 @@ class TucsenCamera(AbstractCamera):
 
         return image_np
 
+    @staticmethod
+    def _convert_header_to_numpy(header: TUCAM_RAWIMG_HEADER) -> np.ndarray:
+        # TODO: In the latest version of 400BSI V3, the readout data will match the
+        # actual bit depth. We can't tell firmware version from SN yet, so we keep a
+        # 16-bit buffer for old demo units. (Carried over from _convert_frame_to_numpy.)
+        #
+        # We copy usWidth*usHeight*itemsize bytes contiguously and reshape flat, which is
+        # only correct when the raw stream has no per-row/column padding. Reject padded
+        # frames loudly rather than silently interleaving padding into pixels. (See the
+        # hardware-verify item in the design spec.)
+        bytes_per_pixel = np.dtype(np.uint16).itemsize  # MONO16
+        if header.usXPadding or header.usYPadding:
+            raise CameraError(
+                f"Padded frames are not supported (usXPadding={header.usXPadding}, "
+                f"usYPadding={header.usYPadding}); a flat reshape would corrupt pixels."
+            )
+        expected = header.usWidth * header.usHeight * bytes_per_pixel
+        if header.uiImgSize < expected:
+            raise CameraError(
+                f"Frame size {header.uiImgSize} < expected {expected} " f"({header.usWidth}x{header.usHeight} MONO16)"
+            )
+        buf = create_string_buffer(expected)
+        memmove(buf, c_void_p(header.pImgData), expected)
+        image_np = np.frombuffer(bytes(buf), dtype=np.uint16).reshape((header.usHeight, header.usWidth))
+        return image_np
+
     def read_camera_frame(self) -> Optional[CameraFrame]:
         if not self.get_is_streaming():
             self._log.error("Cannot read camera frame when not streaming.")

--- a/software/tests/control/test_camera_tucsen.py
+++ b/software/tests/control/test_camera_tucsen.py
@@ -1,0 +1,72 @@
+import ctypes
+
+import numpy as np
+import pytest
+
+# The TUCam SDK shared library is loaded at import time (control/TUCam.py).
+# Skip the whole module where it is not installed (e.g. CI without the SDK).
+try:
+    from control.TUCam import TUCAM_RAWIMG_HEADER
+    from control.camera_tucsen import TucsenCamera
+    from squid.abc import CameraError
+except OSError as e:  # libTUCam.so.1 / TUCam.dll not present
+    pytest.skip(f"TUCam SDK not available: {e}", allow_module_level=True)
+
+
+def _make_header(arr: np.ndarray):
+    """Build a TUCAM_RAWIMG_HEADER pointing at a real ctypes buffer holding `arr`.
+
+    Returns (header, backing_buffer). The caller MUST keep backing_buffer alive
+    for as long as header.pImgData is used — pImgData is a raw pointer into it.
+    """
+    raw = arr.astype(np.uint16).tobytes()
+    backing = ctypes.create_string_buffer(raw, len(raw))
+    header = TUCAM_RAWIMG_HEADER()
+    header.usWidth = arr.shape[1]
+    header.usHeight = arr.shape[0]
+    header.uiImgSize = len(raw)
+    header.pImgData = ctypes.cast(backing, ctypes.c_void_p)
+    return header, backing
+
+
+def test_convert_header_to_numpy_roundtrips_pixels():
+    arr = np.arange(2 * 3, dtype=np.uint16).reshape(2, 3)
+    header, _backing = _make_header(arr)
+
+    out = TucsenCamera._convert_header_to_numpy(header)
+
+    assert out.shape == (2, 3)
+    assert out.dtype == np.uint16
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_convert_header_to_numpy_copies_data():
+    # The returned array must own its data (copied from device memory), so it
+    # stays valid after the source buffer is dropped — it must not alias pImgData.
+    arr = np.array([[7, 8], [9, 10]], dtype=np.uint16)
+    header, backing = _make_header(arr)
+
+    out = TucsenCamera._convert_header_to_numpy(header)
+
+    # Drop the source buffer and mutate its bytes; `out` must be unaffected.
+    ctypes.memset(backing, 0, len(backing))
+    del backing
+    np.testing.assert_array_equal(out, [[7, 8], [9, 10]])
+
+
+def test_convert_header_to_numpy_rejects_short_buffer():
+    arr = np.arange(2 * 3, dtype=np.uint16).reshape(2, 3)
+    header, _backing = _make_header(arr)
+    header.uiImgSize = 4  # smaller than usWidth*usHeight*2 == 12
+
+    with pytest.raises(CameraError):
+        TucsenCamera._convert_header_to_numpy(header)
+
+
+def test_convert_header_to_numpy_rejects_padding():
+    arr = np.arange(2 * 3, dtype=np.uint16).reshape(2, 3)
+    header, _backing = _make_header(arr)
+    header.usXPadding = 1  # per-row padding would corrupt a flat reshape
+
+    with pytest.raises(CameraError):
+        TucsenCamera._convert_header_to_numpy(header)


### PR DESCRIPTION
## Summary

Switches the Tucsen camera driver (`control/camera_tucsen.py`) from a **polling read thread** (`_wait_for_frame` looping on `TUCAM_Buf_WaitForFrame`) to a **registered TUCam buffer callback** (`TUCAM_Buf_DataCallBack`), as suggested by Tucsen. Frames are now delivered as soon as the SDK has them, on TUCam's internal thread.

## What changed

- **New `_on_frame_callback`** — invoked by the SDK per frame; pulls the frame via `TUCAM_Buf_GetData` into a `TUCAM_RAWIMG_HEADER`, converts to numpy, publishes `_current_frame`, and propagates.
- **New `_convert_header_to_numpy`** (static, unit-tested) — converts the raw header to a MONO16 numpy image. Copies exactly `w*h*itemsize` bytes and **rejects padded frames** (`usXPadding`/`usYPadding`) loudly rather than silently corrupting a flat reshape.
- **Per-cycle callback registration** in `start_streaming` (immediately before `Cap_Start`), matching the vendor examples — it isn't documented that a single registration survives `Cap_Stop`/`Cap_Start` + buffer realloc cycles.
- **`stop_streaming`** keeps the vendor `AbortWait → Cap_Stop` order; the polling thread and its helpers (`_wait_for_frame`, `_ensure_read_thread_running`, `_cleanup_read_thread`, all `_read_thread*` state) are removed, along with the now-unused `_convert_frame_to_numpy`.
- **`close()`** now stops streaming first (best-effort — a stop failure no longer aborts handle/SDK teardown).

## Design notes

- Mirrors the in-tree **ToupCam** driver: a single lock held across the device read + frame publish, with `_propogate_frame` outside the lock.
- The existing **`_frame_lock` does double duty** — it also wraps `TUCAM_Buf_Release` + `_allocate_buffer` in `_update_internal_settings`. Since Tucsen's buffer is SDK-owned C memory (unlike ToupCam's refcounted `bytes`), this serializes the free/realloc against the callback's read and **closes a use-after-free by construction**, without depending on whether `Cap_Stop` drains in-flight callbacks.
- Dropped the vendor examples' `CONTEXT_CALLBACK(self.__class__)` idiom — `BUFFER_CALLBACK` is a zero-arg `CFUNCTYPE`, so the SDK never delivers a context; that value was an inert (and potentially dangerous) function-pointer thunk. We pass `None` and keep only the callback object alive for GC.

## Testing

**Headless (done):**
- `tests/control/test_camera_tucsen.py` — 4 unit tests for `_convert_header_to_numpy` (roundtrip, copy-ownership, short-buffer + padding rejection). Module-skips where the TUCam SDK lib is absent.
- `import control.camera_tucsen` clean; `black --check` clean.

**Hardware (⚠️ NOT yet done — blocker is upstream of this change):**
A Tucsen camera was connected (`5453:e437`, healthy on USB3), but the installed TUCam SDK (`/lib/libTUCam.so.1`, Dec 2024) enumerated **0 cameras** — on both init paths, with retries, and after a USB reset — so the driver could not be exercised. The camera presents a generic "25MP USB3.0 Camera" descriptor, suggesting an SDK-version/firmware-handshake mismatch rather than a code issue.

The following must be verified on hardware before merge (a ready harness exists: `PYTHONPATH=. python3 tools/tucsen_callback_smoketest.py`, not included in this PR):
- [ ] Continuous (`TUCCM_SEQUENCE`) — callback stream, `frame_id` advances
- [ ] Software trigger — `send_trigger` → callback → `read_camera_frame` returns
- [ ] Hardware trigger (`TUCCM_TRIGGER_STANDARD`)
- [ ] GenICam (Aries) software/hardware trigger paths
- [ ] Raw-format equivalence — `uiImgSize == w*h*2`, no padding
- [ ] Start/stop/rebin soak — no hang/segfault (exercises the `_frame_lock` serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
