### PR TITLE
fix(filter-wheel): recover from CMD_EXECUTION_ERROR on post-home offset move

### DIFF
--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -31,6 +31,8 @@ import squid.logging
 import squid.stage.cephla
 import squid.stage.utils
 
+_log = squid.logging.get_logger(__name__)
+
 if control._def.USE_XERYON:
     from control.objective_changer_2_pos_controller import (
         ObjectiveChanger2PosController,
@@ -255,7 +257,20 @@ class MicroscopeAddons:
             fw_config = squid.config.get_filter_wheel_config()
             self.emission_filter_wheel.initialize(fw_config.indices)
             if not skip_init:
-                self.emission_filter_wheel.home()
+                try:
+                    self.emission_filter_wheel.home()
+                except Exception:
+                    # A filter-wheel homing failure must not brick the whole
+                    # microscope: the wheel controller already leaves its tracked
+                    # position unset on failure, so come up with the position
+                    # unknown and let the operator re-home from the GUI rather
+                    # than aborting startup before the window even opens.
+                    _log.error(
+                        "Filter wheel homing failed during startup; continuing with the "
+                        "filter wheel position unknown. Re-home from the GUI before relying "
+                        "on filter selection.",
+                        exc_info=True,
+                    )
         if self.piezo_stage and not skip_init:
             self.piezo_stage.home()
         if self.squid_laser_engine:

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -256,9 +256,30 @@ class SquidFilterWheel(AbstractFilterWheelController):
             )
             raise
 
+        offset_usteps = self._delta_to_usteps(config.offset)
         try:
-            self._move_to_usteps(wheel_id, self._delta_to_usteps(config.offset))
+            self._move_to_usteps(wheel_id, offset_usteps)
             self.microcontroller.wait_till_operation_is_completed()
+        except CommandAborted as e:
+            # Same recoverable rejection _move_to_position handles: the firmware
+            # rejected the MOVETO before the motor moved (CMD_EXECUTION_ERROR),
+            # so a plain resend is safe. Mirror that single resend here so a
+            # transient abort doesn't turn homing — which runs uncaught during
+            # startup — into a fatal crash. Re-homing is not a recovery option
+            # (we are already inside the home path), so a failed resend or any
+            # other error type propagates to the caller.
+            _log.warning(f"Filter wheel {wheel_id} offset move aborted ({e}); resending in software...")
+            self.microcontroller.acknowledge_aborted_command()
+            try:
+                self._move_to_usteps(wheel_id, offset_usteps)
+                self.microcontroller.wait_till_operation_is_completed()
+            except Exception:
+                _log.error(
+                    f"Filter wheel {wheel_id} home succeeded but offset move "
+                    f"failed after resend; wheel is at the home reference, not "
+                    f"slot {config.min_index}. Tracked position not updated."
+                )
+                raise
         except Exception:
             _log.error(
                 f"Filter wheel {wheel_id} home succeeded but offset move "

--- a/software/tests/control/test_microscope.py
+++ b/software/tests/control/test_microscope.py
@@ -85,6 +85,31 @@ def test_prepare_for_use_skips_homing_when_flag_set(mock_get_fw_config):
     mock_piezo_stage.home.assert_called_once()
 
 
+@patch("squid.config.get_filter_wheel_config")
+def test_prepare_for_use_contains_filter_wheel_homing_failure(mock_get_fw_config):
+    """A filter wheel homing failure during startup must be contained, not crash
+    the whole microscope build.
+
+    The wheel is left at an unknown position, but the GUI should still come up so
+    the user can re-home — a recoverable hardware hiccup must not brick startup.
+    """
+    from control.microcontroller import CommandAborted
+
+    mock_fw_config = MagicMock()
+    mock_fw_config.indices = [1]
+    mock_get_fw_config.return_value = mock_fw_config
+
+    mock_filter_wheel = MagicMock()
+    mock_filter_wheel.home.side_effect = CommandAborted(reason="firmware reported CMD_EXECUTION_ERROR", command_id=1)
+
+    addons = control.microscope.MicroscopeAddons(emission_filter_wheel=mock_filter_wheel)
+
+    # Must NOT raise — the homing failure is contained so startup continues.
+    addons.prepare_for_use(skip_init=False)
+
+    mock_filter_wheel.home.assert_called_once()
+
+
 def test_simulated_scope_basic_ops():
     scope = control.microscope.Microscope.build_from_global_config(True)
 

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -261,6 +261,76 @@ class TestSquidFilterWheelAbsoluteMove:
         assert wheel_inst._positions[1] == w_config.min_index
 
     @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
+    def test_home_offset_move_command_aborted_triggers_resend(self, motor_slot, move_to_attr, move_rel_attr, home_attr):
+        """CMD_EXECUTION_ERROR on the post-home offset move → ack + resend the
+        same MOVETO (mirrors _move_to_position); homing then completes.
+
+        The firmware can reject this MOVETO before the motor moves; a plain
+        resend is safe, so a single transient abort must not abort homing.
+        """
+        from control.microcontroller import CommandAborted
+
+        wheel_inst, mc, config = self._build_wheel(motor_slot)
+        # Start away from min_index so a successful home is observable as a reset.
+        wheel_inst._positions[1] = 5
+
+        # home wait OK; offset move aborts; resend OK.
+        mc.wait_till_operation_is_completed.side_effect = [
+            None,  # home wait
+            CommandAborted(reason="firmware reported CMD_EXECUTION_ERROR", command_id=1),
+            None,  # resend wait
+        ]
+
+        wheel_inst._home_wheel(1)
+
+        getattr(mc, home_attr).assert_called_once()
+        # Offset MOVETO issued twice: initial attempt + resend.
+        assert getattr(mc, move_to_attr).call_count == 2
+        mc.acknowledge_aborted_command.assert_called_once()
+        # Absolute-MOVETO path must not fall back to relative MOVE.
+        getattr(mc, move_rel_attr).assert_not_called()
+        assert wheel_inst._positions[1] == config.min_index
+
+    @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
+    def test_home_offset_move_resend_failure_propagates(self, motor_slot, move_to_attr, move_rel_attr, home_attr):
+        """If the offset-move resend also fails, _home_wheel re-raises and leaves
+        the tracked position untouched (wheel is at the home reference, not slot 1)."""
+        from control.microcontroller import CommandAborted
+
+        wheel_inst, mc, config = self._build_wheel(motor_slot)
+        wheel_inst._positions[1] = 5
+
+        mc.wait_till_operation_is_completed.side_effect = [
+            None,  # home wait
+            CommandAborted(reason="firmware reported CMD_EXECUTION_ERROR", command_id=1),
+            CommandAborted(reason="firmware reported CMD_EXECUTION_ERROR", command_id=2),
+        ]
+
+        with pytest.raises(CommandAborted):
+            wheel_inst._home_wheel(1)
+
+        # Initial offset MOVETO + one resend, then give up.
+        assert getattr(mc, move_to_attr).call_count == 2
+        # Tracked position must NOT be updated to min_index on failure.
+        assert wheel_inst._positions[1] == 5
+
+    def test_home_offset_move_timeout_does_not_resend(self, wheel):
+        """A TimeoutError on the offset move is NOT resent (motor state uncertain)
+        and re-homing is not attempted from within _home_wheel; it propagates."""
+        wheel_inst, mc = wheel
+
+        mc.wait_till_operation_is_completed.side_effect = [
+            None,  # home wait
+            TimeoutError("offset move ack timeout"),
+        ]
+
+        with pytest.raises(TimeoutError):
+            wheel_inst._home_wheel(1)
+
+        # Only the initial offset MOVETO — no resend on a timeout.
+        assert mc.move_w_to_usteps.call_count == 1
+
+    @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
     def test_rehome_retry_failure_propagates(self, motor_slot, move_to_attr, move_rel_attr, home_attr):
         """When the post-rehome retry also fails, _move_to_position must re-raise."""
         wheel_inst, mc, _ = self._build_wheel(motor_slot)


### PR DESCRIPTION
## Problem

A microscope crashed at startup with an uncaught exception:

```
squid.filter_wheel_controller.cephla - ERROR - Filter wheel 1 home succeeded but offset move failed; wheel is at the home reference, not slot 1.
...
control.microcontroller.CommandAborted: firmware reported CMD_EXECUTION_ERROR
```

The home succeeded, but the **post-home offset move** to slot 1 was rejected by firmware with `CMD_EXECUTION_ERROR`. Because `MicroscopeAddons.prepare_for_use` calls `emission_filter_wheel.home()` with no error handling, the exception propagated through `Microscope.build_from_global_config` to `main_hcs.py` and killed the app before the GUI opened.

## Root cause

An asymmetry introduced by #540: that PR taught `_move_to_position` (normal slot changes) to **recover** from `CMD_EXECUTION_ERROR` — acknowledge the abort and resend the MOVETO. But it left the **identical** MOVETO command inside `_home_wheel` with no recovery, so the same recoverable rejection is gracefully absorbed during operation yet **fatal at startup**.

Verified against firmware (`firmware/controller`): a filter-wheel `MOVETO_W` returns `CMD_EXECUTION_ERROR` from exactly two sites (`mark_move_failed` / `report_move_error`), both meaning the motor never moved (wheel not enabled, or target outside `[xmin,xmax]` in `tmc4361A_moveTo`). So a plain resend is the documented-safe recovery — exactly what `_move_to_position` already does.

## Fix (host-side)

- **`squid/filter_wheel_controller/cephla.py`** — `_home_wheel`'s offset move now mirrors `_move_to_position`: on `CommandAborted`, acknowledge + resend once. A failed resend or any other error type (e.g. `TimeoutError`) still propagates; re-homing is not attempted from inside the home path.
- **`control/microscope.py`** — `prepare_for_use` now contains a filter-wheel homing failure: it logs the error with traceback and continues with the wheel position unknown, so a recoverable hiccup no longer bricks the whole GUI (the operator can re-home). Added a module logger.

## Tests (TDD — written first, confirmed failing, then green)

- `_home_wheel` resends on `CommandAborted` and completes homing (W + W2)
- a failed resend re-raises and leaves the tracked position untouched (W + W2)
- a `TimeoutError` on the offset move is **not** resent (guard against over-reach)
- `prepare_for_use` no longer propagates a filter-wheel homing failure

`46 passed` across the filter-wheel and microscope suites; black-clean at 120 chars.

## Out of scope (flagged for later)

A latent firmware robustness gap, not the proven trigger: the W/W2 axes are never range-calibrated (`xmin/xmax` stay full int32) and `finalize_homing_w/w2` ignores the `ERR_OUT_OF_RANGE` return from `setCurrentPosition`. Worth hardening separately if filter-wheel `CMD_EXECUTION_ERROR`s recur on a specific machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)