### PR TITLE
fix(mosaic): keep Full View tiles across magnification changes

### DIFF
--- a/software/control/core/mosaic_utils.py
+++ b/software/control/core/mosaic_utils.py
@@ -148,6 +148,43 @@ def downsample_tile(
     return downsampled
 
 
+def resample_tile_to_pixel_size(
+    tile: np.ndarray,
+    source_pixel_size_um: float,
+    target_pixel_size_um: float,
+) -> np.ndarray:
+    """Resample a tile so its pixel size is (nominally) ``target_pixel_size_um``.
+
+    Unlike :func:`downsample_tile` (integer downsample factors only), this resamples
+    to an exact target so tiles acquired at different magnifications all land on one
+    shared grid in Full View. Output dims are ``round(dim * source / target)``, so the
+    rendered pixel size matches the target to within integer-dimension rounding.
+
+    Shrinking (source < target) reuses the fast pyrDown chain; enlarging (objective
+    coarser than target) uses INTER_LINEAR. Returns the tile unchanged when the output
+    dimensions equal the input.
+    """
+    if source_pixel_size_um <= 0 or target_pixel_size_um <= 0:
+        return tile
+
+    scale = source_pixel_size_um / target_pixel_size_um
+    new_width = max(1, int(round(tile.shape[1] * scale)))
+    new_height = max(1, int(round(tile.shape[0] * scale)))
+
+    if new_width == tile.shape[1] and new_height == tile.shape[0]:
+        return tile
+
+    if scale < 1.0:
+        resampled = _pyrdown_chain(tile, new_width, new_height)
+    else:
+        resampled = cv2.resize(tile, (new_width, new_height), interpolation=cv2.INTER_LINEAR)
+
+    if resampled.dtype != tile.dtype:
+        resampled = resampled.astype(tile.dtype)
+
+    return resampled
+
+
 def parse_well_id(well_id: str) -> Tuple[int, int]:
     """Parse well ID string to (row, col) indices.
 

--- a/software/control/widgets_mosaic.py
+++ b/software/control/widgets_mosaic.py
@@ -34,7 +34,7 @@ from napari.utils.colormaps import AVAILABLE_COLORMAPS
 
 import control._def
 from control._def import CHANNEL_COLORS_MAP, FILE_ID_PADDING
-from control.core.mosaic_utils import downsample_tile, format_well_id, parse_well_id
+from control.core.mosaic_utils import downsample_tile, format_well_id, parse_well_id, resample_tile_to_pixel_size
 from control.utils import ensure_directory_exists, serialize_for_yaml
 from control.utils_channel import extract_wavelength_from_config_name
 import squid.logging
@@ -451,28 +451,37 @@ class UnifiedMosaicWidget(QWidget):
         y_mm = update.y_mm
         channel_name = update.channel_name
 
-        # Pixel size feeds both downsample_factor and viewer_pixel_size_mm,
-        # which in turn drive every tile coordinate on the canvas. A
-        # mid-session change (Preferences → Mosaic Target Pixel Size,
-        # objective swap, or binning change) makes already-placed tiles
-        # land at coordinates inconsistent with new ones. Detect and reset.
+        # Pixel size drives every tile coordinate on the canvas, so all tiles
+        # on one canvas must agree on it. The two modes reach that agreement
+        # differently (see each branch).
         target_pixel_size_um = float(control._def.MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM)
         live_pixel_size_um = self.objectiveStore.get_pixel_size_factor() * self.camera.get_pixel_size_binned_um()
-        live_downsample = max(1, int(round(target_pixel_size_um / live_pixel_size_um)))
-        if self._pixel_size_um > 0.0 and (
-            not math.isclose(live_pixel_size_um, self._pixel_size_um) or live_downsample != self._downsample_factor
-        ):
-            self._log.info("Pixel size changed since last tile; clearing canvas to keep tile positions consistent.")
-            self.clearAllLayers()
 
-        if self._pixel_size_um == 0.0:
-            self._pixel_size_um = live_pixel_size_um
-            # Must match downsample_tile() and _emit_plate_layout, else
-            # image_pixel_size_mm diverges from the rendered canvas.
-            self._downsample_factor = live_downsample
+        if self.mode == DisplayMode.MOSAIC:
+            # Full View renders every tile at EXACTLY the target pixel size, so tiles
+            # from any magnification share one grid and coexist. Only a change to the
+            # target itself (Preferences) forces a clear — objective/binning never do.
+            if self.layers_initialized and not math.isclose(self.viewer_pixel_size_mm, target_pixel_size_um / 1000):
+                self._log.info("Mosaic target pixel size changed; clearing canvas.")
+                self.clearAllLayers()
+            image = resample_tile_to_pixel_size(image, live_pixel_size_um, target_pixel_size_um)
+            image_pixel_size_mm = target_pixel_size_um / 1000
+        else:
+            # Plate View keeps the integer-factor downsample: the slot geometry in
+            # multi_point_worker._emit_plate_layout is sized to match int(round(target/source)),
+            # so the rendered effective pixel size must use the same integer factor.
+            live_downsample = max(1, int(round(target_pixel_size_um / live_pixel_size_um)))
+            if self._pixel_size_um > 0.0 and (
+                not math.isclose(live_pixel_size_um, self._pixel_size_um) or live_downsample != self._downsample_factor
+            ):
+                self._log.info("Pixel size changed since last tile; clearing canvas to keep tile positions consistent.")
+                self.clearAllLayers()
+            if self._pixel_size_um == 0.0:
+                self._pixel_size_um = live_pixel_size_um
+                self._downsample_factor = live_downsample
+            image = downsample_tile(image, self._pixel_size_um, target_pixel_size_um)
+            image_pixel_size_mm = (self._pixel_size_um * self._downsample_factor) / 1000
 
-        image = downsample_tile(image, self._pixel_size_um, target_pixel_size_um)
-        image_pixel_size_mm = (self._pixel_size_um * self._downsample_factor) / 1000
         tl_x_mm = x_mm - (image.shape[1] * image_pixel_size_mm) / 2
         tl_y_mm = y_mm - (image.shape[0] * image_pixel_size_mm) / 2
 

--- a/software/tests/control/core/test_mosaic_utils.py
+++ b/software/tests/control/core/test_mosaic_utils.py
@@ -9,6 +9,7 @@ from control.core.mosaic_utils import (
     _pyrdown_chain,
     calculate_overlap_pixels,
     downsample_tile,
+    resample_tile_to_pixel_size,
     parse_well_id,
     format_well_id,
 )
@@ -401,3 +402,35 @@ class TestDownsamplingPerformance:
         # INTER_LINEAR should be fastest
         assert times[DownsamplingMethod.INTER_LINEAR] < times[DownsamplingMethod.INTER_AREA_FAST]
         assert times[DownsamplingMethod.INTER_LINEAR] < times[DownsamplingMethod.INTER_AREA]
+
+
+class TestResampleTileToPixelSize:
+    def test_shrinks_to_exact_dims(self):
+        tile = np.full((100, 100), 100, dtype=np.uint16)
+        out = resample_tile_to_pixel_size(tile, 1.0, 2.0)  # scale 0.5
+        assert out.shape == (50, 50)
+
+    def test_large_shrink(self):
+        tile = np.full((1000, 1000), 100, dtype=np.uint16)
+        out = resample_tile_to_pixel_size(tile, 0.2, 2.0)  # scale 0.1
+        assert out.shape == (100, 100)
+
+    def test_enlarges_when_source_coarser_than_target(self):
+        tile = np.full((100, 100), 100, dtype=np.uint16)
+        out = resample_tile_to_pixel_size(tile, 4.0, 2.0)  # scale 2.0
+        assert out.shape == (200, 200)
+
+    def test_identity_when_source_equals_target(self):
+        tile = np.full((100, 100), 100, dtype=np.uint16)
+        out = resample_tile_to_pixel_size(tile, 2.0, 2.0)
+        assert out is tile
+
+    def test_preserves_dtype(self):
+        tile = np.full((100, 100), 100, dtype=np.uint16)
+        out = resample_tile_to_pixel_size(tile, 1.0, 2.0)
+        assert out.dtype == np.uint16
+
+    def test_preserves_rgb_channels(self):
+        tile = np.full((100, 100, 3), 100, dtype=np.uint8)
+        out = resample_tile_to_pixel_size(tile, 1.0, 2.0)
+        assert out.shape == (50, 50, 3)

--- a/software/tests/control/test_unified_mosaic_widget.py
+++ b/software/tests/control/test_unified_mosaic_widget.py
@@ -1,6 +1,10 @@
-import numpy as np
+import types
 
-from control.widgets_mosaic import DisplayMode, blit_tiles_to_canvas
+import numpy as np
+import pytest
+
+import control._def
+from control.widgets_mosaic import DisplayMode, UnifiedMosaicWidget, blit_tiles_to_canvas
 
 
 class TestCanvasBlit:
@@ -49,3 +53,105 @@ class TestCanvasBlit:
     def test_display_mode_values(self):
         assert DisplayMode.MOSAIC.value == "mosaic"
         assert DisplayMode.PLATE.value == "plate"
+
+
+class _FakeObjectiveStore:
+    def __init__(self, factor):
+        self.factor = factor
+
+    def get_pixel_size_factor(self):
+        return self.factor
+
+
+class _FakeCamera:
+    def get_pixel_size_binned_um(self):
+        return 1.0  # live_pixel_size_um == objective factor
+
+
+class _FakeContrast:
+    def get_scaled_limits(self, name, dtype):
+        return (0, 255)
+
+    def update_limits(self, *args, **kwargs):
+        pass
+
+
+def _tile_update(image, x_mm, y_mm, channel="BF", **extra):
+    u = types.SimpleNamespace(
+        image=image,
+        x_mm=x_mm,
+        y_mm=y_mm,
+        channel_name=channel,
+        well_origin_mm=None,
+        well_id=None,
+        well_row=0,
+        well_col=0,
+    )
+    for k, v in extra.items():
+        setattr(u, k, v)
+    return u
+
+
+@pytest.fixture
+def mosaic_widget(qtbot, monkeypatch):
+    monkeypatch.setattr(control._def, "MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM", 2.0)
+    obj = _FakeObjectiveStore(factor=1.85)
+    widget = UnifiedMosaicWidget(obj, _FakeCamera(), _FakeContrast())
+    qtbot.addWidget(widget)
+    widget.mode = DisplayMode.MOSAIC
+    return widget, obj
+
+
+class TestFullViewMagnificationPersistence:
+    def test_persists_tiles_across_magnification_change(self, mosaic_widget):
+        widget, obj = mosaic_widget
+        widget.updateTile(_tile_update(np.full((100, 100), 200, dtype=np.uint8), 10.0, 10.0))
+        assert widget.viewer_pixel_size_mm == pytest.approx(0.002)
+        low_nonzero = int(np.count_nonzero(widget.viewer.layers["BF"].data))
+        assert low_nonzero > 0
+
+        # Higher magnification, different location.
+        obj.factor = 0.37
+        widget.updateTile(_tile_update(np.full((100, 100), 150, dtype=np.uint8), 12.0, 12.0))
+
+        assert widget.layers_initialized is True
+        assert widget.viewer_pixel_size_mm == pytest.approx(0.002)  # constant, no re-init
+        total_nonzero = int(np.count_nonzero(widget.viewer.layers["BF"].data))
+        assert total_nonzero > low_nonzero  # low-mag tile retained AND high-mag tile added
+
+    def test_clears_when_target_pixel_size_changes(self, mosaic_widget, monkeypatch):
+        widget, obj = mosaic_widget
+        widget.updateTile(_tile_update(np.full((100, 100), 200, dtype=np.uint8), 10.0, 10.0))
+        assert widget.viewer_pixel_size_mm == pytest.approx(0.002)
+
+        monkeypatch.setattr(control._def, "MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM", 5.0)
+        widget.updateTile(_tile_update(np.full((100, 100), 150, dtype=np.uint8), 30.0, 30.0))
+
+        assert widget.viewer_pixel_size_mm == pytest.approx(0.005)  # re-init at new target
+        # Only the new tile remains (round(100 * 1.85 / 5) == 37), not a canvas spanning 10..30 mm.
+        assert widget.viewer.layers["BF"].data.shape == (37, 37)
+
+    def test_plate_view_still_uses_integer_downsample(self, qtbot, monkeypatch):
+        monkeypatch.setattr(control._def, "MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM", 2.0)
+        obj = _FakeObjectiveStore(factor=0.74)  # int(round(2/0.74)) == 3 -> 2.22 um
+        widget = UnifiedMosaicWidget(obj, _FakeCamera(), _FakeContrast())
+        qtbot.addWidget(widget)
+        widget.mode = DisplayMode.PLATE
+        widget.setPlateLayout(
+            types.SimpleNamespace(
+                num_rows=2, num_cols=2, well_slot_shape=(200, 200), fov_grid_shape=(1, 1), well_ids=["A1"]
+            )
+        )
+        widget.updateTile(
+            _tile_update(
+                np.full((100, 100), 200, dtype=np.uint8),
+                10.0,
+                10.0,
+                well_origin_mm=(10.0, 10.0),
+                well_id="A1",
+                well_row=0,
+                well_col=0,
+            )
+        )
+        # Integer factor 3 -> 2.22 um, NOT the exact target 2.0 um.
+        assert widget.viewer_pixel_size_mm == pytest.approx(0.00222, abs=1e-5)


### PR DESCRIPTION
## Problem

In **Full View** (mosaic mode), switching magnification mid-session **wiped the previously displayed images** — you couldn't keep a low-mag overview while adding higher-mag detail.

**Root cause:** Full View placed every tile on one shared grid at one pixel size, downsampling toward `MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM` with an **integer** factor. Each objective therefore landed at a *different* effective µm/px (4x→1.85, 10x→2.22, 20x→1.85, 40x→2.035 for a 2 µm target), so two magnifications could not coexist on one grid — and `updateTile()` resolved this by clearing the canvas on any pixel-size change.

(The separate "ROI shift across magnifications" the user also observed was confirmed to be **physical parcentric offset** between objectives — a hardware/calibration matter. A headless repro showed the software coordinate round-trip is exact; this PR makes the software contribution to alignment exactly zero but does not correct parcentric error.)

## Fix

Render every **Full View** tile at *exactly* the target pixel size instead of an integer-rounded factor. With the rendered pixel size now constant, all magnifications share one grid and the existing single-grid machinery (placement, growth, ROI repositioning) keeps working unchanged — so the canvas is cleared **only** when the target pixel size itself changes (Preferences), never on objective/binning change. Newer tiles still overwrite older in overlap, as before.

**Plate View is untouched** — it keeps the integer-factor `downsample_tile` because `multi_point_worker._emit_plate_layout` sizes well slots to match that integer factor.

### Changes
- `control/core/mosaic_utils.py`: new `resample_tile_to_pixel_size()` — resizes a tile to exactly the target pixel size (reuses the fast pyrDown chain for shrink; `INTER_LINEAR` for the rare coarse-objective upsample).
- `control/widgets_mosaic.py`: `updateTile()` branches the downsample/clear preamble by mode — Full View uses the exact resample + clears only on target change; Plate View keeps the prior integer-factor path verbatim.

## Testing
- 6 unit tests for `resample_tile_to_pixel_size` (shrink, large shrink, upsample, identity, dtype, RGB).
- 3 widget tests: tiles persist across a magnification change; canvas clears when the target pixel size changes; Plate View still uses the integer downsample (regression guard).
- Full mosaic suite: **48 passed, 2 skipped**. Black-clean (120 cols).

## Deferred (optional follow-ups, not in this PR)
- **Absolute-stage-µm invariant cleanup** — delete the `top_left_coordinate` shifting origin + the ROI-reposition hack via per-layer `translate`. Pure elegance; not needed to fix the bugs.
- **Plate View unification** — render Plate View at exactly the target px too, removing the documented worker/widget integer-factor agreement fragility (`_emit_plate_layout`). ~½ day code; dominant cost is plate-scan re-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
