### PR TITLE
fix(laser-engine): bound serial write_timeout so a stuck engine can't hang startup

### DIFF
--- a/software/control/squid_laser_engine.py
+++ b/software/control/squid_laser_engine.py
@@ -489,6 +489,7 @@ class SquidLaserEngine(SquidLaserEngineBase):
     """USB-serial controller. Background query thread + receive thread."""
 
     BAUDRATE = 115200
+    WRITE_TIMEOUT_S = 2.0
 
     def __init__(
         self,
@@ -572,7 +573,7 @@ class SquidLaserEngine(SquidLaserEngineBase):
                 raise RuntimeError(f"SquidLaserEngine: no USB device found with serial number {self.sn!r}")
         elif port_path is None:
             raise RuntimeError("SquidLaserEngine: must provide either sn or device")
-        return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1)
+        return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1, write_timeout=self.WRITE_TIMEOUT_S)
 
     def _write_packet(self, packet: bytes) -> None:
         if self._serial is None or self.is_connection_lost():

--- a/software/tests/control/test_squid_laser_engine.py
+++ b/software/tests/control/test_squid_laser_engine.py
@@ -498,3 +498,58 @@ class TestSquidLaserEngineRealClass:
         qtbot.wait(50)
         assert engine.is_connection_lost() is True
         assert any("simulated drop" in s for s in signals)
+
+    def test_open_serial_sets_write_timeout(self, monkeypatch):
+        # Regression: pyserial defaults write_timeout=None (block forever). Opening the
+        # port without a write timeout let an unresponsive engine hang GUI startup, since
+        # start()/wake_up_all() write on the main thread during prepare_for_use().
+        import control.squid_laser_engine as sle
+
+        class _RecordingSerial(_FakeSerial):
+            last_kwargs: dict = {}
+
+            def __init__(self, port, baudrate=None, timeout=None, write_timeout=None, **kwargs):
+                super().__init__()
+                _RecordingSerial.last_kwargs = {
+                    "port": port,
+                    "baudrate": baudrate,
+                    "timeout": timeout,
+                    "write_timeout": write_timeout,
+                }
+
+        monkeypatch.setattr(sle.serial, "Serial", _RecordingSerial)
+        engine = SquidLaserEngine(device="/dev/fake-laser")
+        engine.start()  # _serial is None here, so start() calls _open_serial() -> serial.Serial(...)
+        try:
+            assert _RecordingSerial.last_kwargs["port"] == "/dev/fake-laser"
+            assert _RecordingSerial.last_kwargs["write_timeout"] == SquidLaserEngine.WRITE_TIMEOUT_S
+            assert _RecordingSerial.last_kwargs["write_timeout"] is not None
+        finally:
+            engine.close()
+
+    def test_write_timeout_does_not_block_startup(self, qtbot):
+        # Regression: wake_up_all() runs synchronously on the main thread during
+        # prepare_for_use(). With a bounded write_timeout, a stuck write raises
+        # SerialTimeoutException, which must turn into a prompt connection-lost rather
+        # than wedging startup forever.
+        import serial
+
+        engine, fake = self._make_engine()
+
+        def raise_timeout(_data):
+            raise serial.SerialTimeoutException("simulated write timeout")
+
+        fake.write = raise_timeout
+        signals = []
+        engine.connection_lost.connect(lambda msg: signals.append(msg))
+        # Mark as "started" without launching background threads so _write_packet takes
+        # the running path (not the shutdown-race early return) and the test is deterministic.
+        engine._running.set()
+
+        t0 = time.time()
+        engine.wake_up_all()
+        elapsed = time.time() - t0
+
+        assert elapsed < 1.0  # returned promptly instead of blocking on the timed-out write
+        assert engine.is_connection_lost() is True
+        assert any("simulated write timeout" in s for s in signals)


### PR DESCRIPTION
## Problem

Starting the software with `USE_SQUID_LASER_ENGINE = True` hangs at startup: the GUI never appears and the Toupcam driver thread keeps logging `frame N (CONTINUOUS): ...` indefinitely. Setting `USE_SQUID_LASER_ENGINE = False` (all else equal) starts normally.

## Root cause

`SquidLaserEngine._open_serial()` opened the port with pyserial's default **`write_timeout=None` (block forever)**:

```python
return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1)
```

`MicroscopeAddons.prepare_for_use()` calls `wake_up_all()` **synchronously on the main thread** during startup (`microscope.py:281`). If the engine device doesn't drain its USB buffer, that `write()` blocks forever, wedging the entire GUI launch. The camera's driver callback thread is independent, so it keeps streaming frames — and because the main thread is parked in a C-level `write()`, a single Ctrl+C can't unstick it.

Confirmed on hardware: opening `/dev/ttyACM1` succeeds instantly, but the first `serial.write()` to it blocks. (The SN→port mapping was correct — this is not a misconfiguration; a robustness gap.)

## Fix

Give the port a bounded `write_timeout`. A stuck write now raises `SerialTimeoutException`, which `_write_packet()` already routes into the existing graceful connection-lost path (`_signal_connection_lost()` + `_running.clear()`). The GUI comes up with the engine marked disconnected instead of hanging; a healthy engine (drains in <1 ms) is unaffected.

## Tests

Added to `tests/control/test_squid_laser_engine.py`:
- `test_open_serial_sets_write_timeout` — `_open_serial()` passes `write_timeout` to `serial.Serial`.
- `test_write_timeout_does_not_block_startup` — a write that raises `SerialTimeoutException` makes `wake_up_all()` return promptly and signal connection-lost, rather than blocking.

`python3 -m pytest tests/control/test_squid_laser_engine.py` → 43 passed. Black clean.

## Note (not addressed here)

The write blocking on the first packet means the device at `/dev/ttyACM1` wasn't draining as a healthy laser engine would (firmware/power/wrong-device). This PR stops the hang; it does not make an unresponsive engine functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)